### PR TITLE
fix threaded conversion with linearisation curves optimisation

### DIFF
--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -215,6 +215,29 @@ void Eval16nop1D(register const cmsUInt16Number Input[],
 }
 
 static
+void PrelinEval16NoAlloc(register const cmsUInt16Number Input[],
+                  register cmsUInt16Number Output[],
+                  register const void* D)
+{
+    Prelin16Data* p16 = (Prelin16Data*) D;
+    cmsUInt16Number  StageABC[MAX_INPUT_DIMENSIONS],
+                     StageDEF[MAX_INPUT_DIMENSIONS];
+    int i;
+
+    for (i=0; i < p16 ->nInputs; i++) {
+
+        p16 ->EvalCurveIn16[i](&Input[i], &StageABC[i], p16 ->ParamsCurveIn16[i]);
+    }
+
+    p16 ->EvalCLUT(StageABC, StageDEF, p16 ->CLUTparams);
+
+    for (i=0; i < p16 ->nOutputs; i++) {
+
+        p16 ->EvalCurveOut16[i](&StageDEF[i], &Output[i], p16 ->ParamsCurveOut16[i]);
+    }
+}
+
+static
 void PrelinEval16(register const cmsUInt16Number Input[],
                   register cmsUInt16Number Output[],
                   register const void* D)
@@ -672,8 +695,10 @@ cmsBool OptimizeByResampling(cmsPipeline** Lut, cmsUInt32Number Intent, cmsUInt3
                                Dest ->OutputChannels,
                                DataSetOut);
 
-
-        _cmsPipelineSetOptimizationParameters(Dest, PrelinEval16, (void*) p16, PrelinOpt16free, Prelin16dup);
+        if(p16 ->nOutputs < MAX_INPUT_DIMENSIONS)
+          _cmsPipelineSetOptimizationParameters(Dest, PrelinEval16NoAlloc, (void*) p16, PrelinOpt16free, Prelin16dup);
+        else
+          _cmsPipelineSetOptimizationParameters(Dest, PrelinEval16, (void*) p16, PrelinOpt16free, Prelin16dup);
     }
 
 
@@ -1076,7 +1101,7 @@ cmsBool OptimizeByComputingLinearization(cmsPipeline** Lut, cmsUInt32Number Inte
             3, OptimizedPrelinCurves, 3, NULL);
         if (p16 == NULL) return FALSE;
 
-        _cmsPipelineSetOptimizationParameters(OptimizedLUT, PrelinEval16, (void*) p16, PrelinOpt16free, Prelin16dup);
+        _cmsPipelineSetOptimizationParameters(OptimizedLUT, PrelinEval16NoAlloc, (void*) p16, PrelinOpt16free, Prelin16dup);
 
     }
 


### PR DESCRIPTION
The first commit fixes following bug, while the second commit is an optimisation to the bug fix.

Bug: Using threads and cmsFLAGS_CLUT_XXX_LINEARIZATION
Above scenario causes unexpected scattered colours.
The effect can be easily observed by using a threaded conversion and enabling
the cmsFLAGS_CLUT_POST_LINEARIZATION and cmsFLAGS_CLUT_PRE_LINEARIZATION
flags. This was seen in Oyranos' image_display viewer, which uses lcms and
OpenMP threads.

The changes fix the above observed bug.
