### PR TITLE
Cosmetic: fix some typos.

### DIFF
--- a/src/cmscgats.c
+++ b/src/cmscgats.c
@@ -30,8 +30,8 @@
 // IT8.7 / CGATS.17-200x handling -----------------------------------------------------------------------------
 
 
-#define MAXID        128     // Max lenght of identifier
-#define MAXSTR      1024     // Max lenght of string
+#define MAXID        128     // Max length of identifier
+#define MAXSTR      1024     // Max length of string
 #define MAXTABLES    255     // Max Number of tables in a single stream
 #define MAXINCLUDE    20     // Max number of nested includes
 
@@ -1547,7 +1547,7 @@ void WriteStr(SAVESTREAM* f, const char *str)
     if (str == NULL)
         str = " ";
 
-    // Lenghth to write
+    // Length to write
     len = (cmsUInt32Number) strlen(str);
     f ->Used += len;
 

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -5058,7 +5058,7 @@ void *Type_Dictionary_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* i
     if (!_cmsReadUInt32Number(io, &Count)) return NULL;
     SizeOfTag -= sizeof(cmsUInt32Number);
 
-    // Get rec lenghth
+    // Get rec length
     if (!_cmsReadUInt32Number(io, &Length)) return NULL;
     SizeOfTag -= sizeof(cmsUInt32Number);
 

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -234,7 +234,7 @@ typedef struct {
     cmsUInt16Number Country;
 
     cmsUInt32Number StrW;       // Offset to current unicode string
-    cmsUInt32Number Len;        // Lenght in bytes
+    cmsUInt32Number Len;        // Length in bytes
 
 } _cmsMLUentry;
 


### PR DESCRIPTION
Hello,

This small cosmetic patch fixes some typos in LCMS. I accidentally noticed them while fixing similar typos in MPC-HC which uses LCMS as a submodule.

Underground78
