### PR TITLE
lcms2.h: fix clash with recent libjpeg

### DIFF
--- a/include/lcms2.h
+++ b/include/lcms2.h
@@ -229,6 +229,10 @@ typedef int                  cmsBool;
 #ifndef TRUE
 #       define TRUE  1
 #endif
+#ifndef HAVE_BOOLEAN
+#       define boolean int
+#       define HAVE_BOOLEAN
+#endif
 
 // D50 XYZ normalized to Y=1.0
 #define cmsD50X             0.9642


### PR DESCRIPTION
lcms tries to be clever defining boolean values when they're not present. Complete this by also defining the boolean type and HAVE_BOOLEAN so that jpeg doesn't try to create an enum for this with the same names.
