### PR TITLE
Fix rounding in ICC version writing

### DIFF
--- a/src/cmsio0.c
+++ b/src/cmsio0.c
@@ -924,7 +924,7 @@ void  CMSEXPORT cmsSetProfileVersion(cmsHPROFILE hProfile, cmsFloat64Number Vers
 
     // 4.2 -> 0x4200000
 
-    Icc -> Version = BaseToBase((cmsUInt32Number) floor(Version * 100.0), 10, 16) << 16;
+    Icc -> Version = BaseToBase((cmsUInt32Number) round(Version * 100.0), 10, 16) << 16;
 }
 
 cmsFloat64Number CMSEXPORT cmsGetProfileVersion(cmsHPROFILE hProfile)


### PR DESCRIPTION
The added unit-test will fail without the change from floor() to round() - setting the version to 2.3 will be read as 2.29.

(Noticed with the colord unittests, which were reading back 4.08 when setting 4.09)
