### PR TITLE
Allow ptr alignment to be set at build time

### DIFF
--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -57,7 +57,15 @@
 #define _cmsALIGNLONG(x) (((x)+(sizeof(cmsUInt32Number)-1)) & ~(sizeof(cmsUInt32Number)-1))
 
 // Alignment to memory pointer
-#define _cmsALIGNMEM(x)  (((x)+(sizeof(void *) - 1)) & ~(sizeof(void *) - 1))
+
+// (Ultra)SPARC with gcc requires ptr alignment of 8 bytes
+// even though sizeof(void *) is only four: for greatest flexibility
+// allow the build to specify ptr alignment.
+#ifndef CMS_PTR_ALIGNMENT
+# define CMS_PTR_ALIGNMENT sizeof(void *)
+#endif
+
+#define _cmsALIGNMEM(x)  (((x)+(CMS_PTR_ALIGNMENT - 1)) & ~(CMS_PTR_ALIGNMENT - 1))
 
 // Maximum encodeable values in floating point
 #define MAX_ENCODEABLE_XYZ  (1.0 + 32767.0/32768.0)


### PR DESCRIPTION
This came up during testing of the second Ghostscript 9.16 release candidate, causing a bus error
on SPARC/Solaris with gcc.

At least some configurations of gcc on UltraSPARC require 8 byte alignment of
memory pointers (even on 32 bit user space, where sizeof(void *) == 4).

Rather than contaminate the source, provide ability to set the ptr alignment
on the compiler command line (on Unix, using CFLAGS when calling configure).
