### PR TITLE
Fix idendity device link with LINEARIZATION flags

### DIFF
--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -675,7 +675,7 @@ cmsBool OptimizeByResampling(cmsPipeline** Lut, cmsUInt32Number Intent, cmsUInt3
         cmsStage* PreLin = cmsPipelineGetPtrToFirstStage(Src);
 
         // Check if suitable
-        if (PreLin ->Type == cmsSigCurveSetElemType) {
+        if (PreLin && PreLin ->Type == cmsSigCurveSetElemType) {
 
             // Maybe this is a linear tram, so we can avoid the whole stuff
             if (!AllCurvesAreLinear(PreLin)) {
@@ -708,7 +708,7 @@ cmsBool OptimizeByResampling(cmsPipeline** Lut, cmsUInt32Number Intent, cmsUInt3
         cmsStage* PostLin = cmsPipelineGetPtrToLastStage(Src);
 
         // Check if suitable
-        if (cmsStageType(PostLin) == cmsSigCurveSetElemType) {
+        if (PostLin && cmsStageType(PostLin) == cmsSigCurveSetElemType) {
 
             // Maybe this is a linear tram, so we can avoid the whole stuff
             if (!AllCurvesAreLinear(PostLin)) {


### PR DESCRIPTION
This patch fixes a segmentation fault on Linux and likely other platforms.
For reproduction use:
$ linkicc -o device_link.icc -l \`oyranos-profile --path sRGB.icc\` \`oyranos-profile --path sRGB.icc\`

Discussion:
The crash happens if two identical profiles are linked to a
device link profile and cmsTransform2DeviceLink() obtains the
cmsFLAGS_CLUT_POST_LINEARIZATION or cmsFLAGS_CLUT_PRE_LINEARIZATION
flags as in the above demo. lcms2.h says to the flags:
define cmsFLAGS_CLUT_POST_LINEARIZATION  0x0001    // create postlinearization tables if possible
That means to my understanding, the flags shall perform a reasonable
fallback, in case the linearisation curves are not created. This patch
lets create a device link profile, even without the curves and
avoids a segmentation fault.