### PR TITLE
Fix possible null pointer dereference

### DIFF
--- a/utils/tificc/tificc.c
+++ b/utils/tificc/tificc.c
@@ -708,7 +708,8 @@ cmsHPROFILE GetTIFFProfile(TIFF* in)
         if (Verbose) {
 
             fprintf(stdout, "\n[Embedded profile]\n");
-            PrintProfileInformation(hProfile);                       
+            if (hProfile != NULL)
+                PrintProfileInformation(hProfile);                       
             fflush(stdout);
         }
 


### PR DESCRIPTION
hProfile is being checked against Null at line no. 716, which means it could be Null. But it is not checked against Null before line no. 711 & it is dereferenced in PrintProfileInformation.