### PR TITLE
Fix typecast for cmsTagSignature

### DIFF
--- a/src/cmsio0.c
+++ b/src/cmsio0.c
@@ -1854,7 +1854,7 @@ cmsBool CMSEXPORT cmsWriteRawTag(cmsHPROFILE hProfile, cmsTagSignature sig, cons
     _cmsUnlockMutex(Icc->ContextID, Icc ->UsrMutex);
 
     if (Icc->TagPtrs[i] == NULL) {           
-           Icc->TagNames[i] = 0;
+           Icc->TagNames[i] = (cmsTagSignature) 0;
            return FALSE;
     }
     return TRUE;


### PR DESCRIPTION
Fix typecast problem in reference to https://github.com/mm2/Little-CMS/issues/48