### PR TITLE
Fix allocation failure check.

### DIFF
--- a/src/cmsplugin.c
+++ b/src/cmsplugin.c
@@ -525,6 +525,7 @@ void* _cmsPluginMalloc(cmsContext ContextID, cmsUInt32Number size)
         if (ContextID == NULL) {
 
             ctx->MemPool = _cmsCreateSubAlloc(0, 2*1024);
+            if (ctx->MemPool == NULL) return NULL;
         }
         else {
             cmsSignalError(ContextID, cmsERROR_CORRUPTION_DETECTED, "NULL memory pool on context");


### PR DESCRIPTION
Checked if _cmsCreateSubAlloc fails to allocate memory.