### PR TITLE
Fix stack buffer overflow in transicc

### DIFF
--- a/utils/transicc/transicc.c
+++ b/utils/transicc/transicc.c
@@ -719,7 +719,7 @@ void TakeFloatValues(cmsFloat64Number Float[])
 {
     cmsUInt32Number i, n;
     char ChannelName[cmsMAX_PATH];
-    char Buffer[cmsMAX_PATH];
+    char Buffer[4096];
 
     if (xisatty(stdin))
         fprintf(stderr, "\nEnter values, 'q' to quit\n");


### PR DESCRIPTION
With reference to https://github.com/mm2/Little-CMS/issues/43
Address sanitizer reported stack buffer overflow.
As Getline function reads 4095, in this case Buffer is of length cmsMAX_PATH(256).
Its length should be 4096.