### PR TITLE
Fix wrong sizeof() in Type_ViewingConditions_Dup(). Fixes "Checking Profile creation" test

### DIFF
--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -3850,7 +3850,7 @@ cmsBool Type_ViewingConditions_Write(struct _cms_typehandler_struct* self, cmsIO
 static
 void* Type_ViewingConditions_Dup(struct _cms_typehandler_struct* self, const void *Ptr, cmsUInt32Number n)
 {
-   return _cmsDupMem(self ->ContextID, Ptr, sizeof(cmsScreening));
+   return _cmsDupMem(self ->ContextID, Ptr, sizeof(cmsICCViewingConditions));
 
    cmsUNUSED_PARAMETER(n);
 }


### PR DESCRIPTION
Found using AddressSanitizer while running  *make check*
With this fix, *make check*  passes fine for me.

In this particular case, **Type_ViewingConditions_Dup()** is called from **cmsWriteTag()** which is called from **CheckICCViewingConditions()** like:
`cmsWriteTag(hProfile, cmsSigViewingConditionsTag, &s);`
while s is defined as:
`cmsICCViewingConditions  s;`
So i think this is just a typo.

Fixes following issue:
```
Checking Profile creation .....................
=================================================================
==14208==ERROR: AddressSanitizer: unknown-crash on address 0x7ffddae721b0 at pc 0x7f5f4322db8d bp 0x7ffddae71ec0 sp 0x7ffddae71eb8
READ of size 392 at 0x7ffddae721b0 thread T0
    0 0x7f5f4322db8c in _cmsDupDefaultFn /home/lebedevri/src/Little-CMS/src/cmserr.c:172
    1 0x7f5f4322dfa9 in _cmsDupMem /home/lebedevri/src/Little-CMS/src/cmserr.c:302
    2 0x7f5f4327e8a4 in Type_ViewingConditions_Dup /home/lebedevri/src/Little-CMS/src/cmstypes.c:3853
    3 0x7f5f432453e8 in cmsWriteTag /home/lebedevri/src/Little-CMS/src/cmsio0.c:1686
    4 0x41bd9c in CheckICCViewingConditions /home/lebedevri/src/Little-CMS/testbed/testcms2.c:4992
    5 0x41bd9c in CheckProfileCreation /home/lebedevri/src/Little-CMS/testbed/testcms2.c:5319
    6 0x40f653 in Check /home/lebedevri/src/Little-CMS/testbed/testcms2.c:310
    7 0x422614 in main /home/lebedevri/src/Little-CMS/testbed/testcms2.c:8339
    8 0x7f5f41959b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    9 0x4056d8 (/home/lebedevri/src/Little-CMS/testbed/.libs/testcms+0x4056d8)

Address 0x7ffddae721b0 is located in stack of thread T0 at offset 96 in frame
    0 0x41a220 in CheckProfileCreation /home/lebedevri/src/Little-CMS/testbed/testcms2.c:5192

  This frame has 7 object(s):
    [32, 56) 'Curves'
    [96, 152) 's' <== Memory access at offset 96 partially overflows this variable
    [192, 264) 'CHAD' <== Memory access at offset 96 partially underflows this variable
    [320, 392) 'c' <== Memory access at offset 96 partially underflows this variable
    [448, 455) 'Buffer' <== Memory access at offset 96 partially underflows this variable
    [512, 528) 'c'
    [576, 832) 'Buffer'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: unknown-crash /home/lebedevri/src/Little-CMS/src/cmserr.c:172 _cmsDupDefaultFn
Shadow bytes around the buggy address:
  0x10003b5c63e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003b5c63f0: f1 f1 f1 f1 04 f4 f4 f4 f2 f2 f2 f2 00 00 00 00
  0x10003b5c6400: 00 00 00 f4 f2 f2 f2 f2 05 f4 f4 f4 f2 f2 f2 f2
  0x10003b5c6410: 05 f4 f4 f4 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003b5c6420: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 00
=>0x10003b5c6430: 00 f4 f2 f2 f2 f2[00]00 00 00 00 00 00 f4 f2 f2
  0x10003b5c6440: f2 f2 00 00 00 00 00 00 00 00 00 f4 f4 f4 f2 f2
  0x10003b5c6450: f2 f2 00 00 00 00 00 00 00 00 00 f4 f4 f4 f2 f2
  0x10003b5c6460: f2 f2 07 f4 f4 f4 f2 f2 f2 f2 00 00 f4 f4 f2 f2
  0x10003b5c6470: f2 f2 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003b5c6480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==14208==ABORTING
```

Thanks.