### PR TITLE
Set LD_LIBRARY_PATH in testbed so just-built LCMS is tested

### DIFF
--- a/testbed/Makefile.am
+++ b/testbed/Makefile.am
@@ -23,7 +23,7 @@ check:
 	if [ $(top_srcdir) != $(top_builddir) ]; then \
 		cp $(top_srcdir)/testbed/*.ic? $(top_builddir)/testbed; \
 	fi
-	./testcms
+	LD_LIBRARY_PATH=$(top_builddir)/src/.libs ./testcms
 	if [ $(top_srcdir) != $(top_builddir) ]; then \
 		rm -f $(top_builddir)/testbed/*.ic?; \
 	fi


### PR DESCRIPTION
When 'make check' is run, ./testcms is run in testbed/Makefile. This uses the default library path, and so will use an existing LCMS 2 installation or fail if LCMS 2 is not already installed. This patch fixes the Makefile so the tests can be run after build, but before install, to test the just-built LCMS 2.

I haven't re-generated the checked-in autotools files as they were built using a different version to the one I have locally and running them generates a raft of spurious changes.
