### PR TITLE
Fix heap-buffer-overflow in FloatXFORM().

### DIFF
--- a/src/cmsxform.c
+++ b/src/cmsxform.c
@@ -249,7 +249,7 @@ void FloatXFORM(_cmsTRANSFORM* p,
     cmsUInt8Number* output;
     cmsFloat32Number fIn[cmsMAXCHANNELS], fOut[cmsMAXCHANNELS];
     cmsFloat32Number OutOfGamut;
-    cmsUInt32Number i, j, strideIn, strideOut;
+    cmsUInt32Number i, j, c, strideIn, strideOut;
 
     _cmsHandleExtraChannels(p, in, out, PixelsPerLine, LineCount, Stride);
 
@@ -275,8 +275,8 @@ void FloatXFORM(_cmsTRANSFORM* p,
             if (OutOfGamut > 0.0) {
 
                 // Certainly, out of gamut
-                for (j=0; j < cmsMAXCHANNELS; j++)
-                    fOut[j] = -1.0;
+                for (c = 0; c < cmsMAXCHANNELS; c++)
+                    fOut[c] = -1.0;
 
             }
             else {


### PR DESCRIPTION
This is a regression:
```
$ git bisect log
# bad: [e228b485db717d81e58407986a6fff216ff77c36] Merge pull request #61 from ya1gaurav/patch-11
# good: [f20b84fe595cfe27b8b10e84248d8c94e26f8d20] Added a version retrieval function
git bisect start 'master' 'lcms2-2.7'
# bad: [288c1505e78ef7d94ecc67729fdca91151f74bac] Updated autotools
git bisect bad 288c1505e78ef7d94ecc67729fdca91151f74bac
# good: [b32dcedd13b3fc2ea7a8099cc0f67eaa31b8c298] Simplify/Improve endian decisions in lcms2.h
git bisect good b32dcedd13b3fc2ea7a8099cc0f67eaa31b8c298
# bad: [adb64b44364e3cd8fabc5a58a0da6841195348ca] New docs
git bisect bad adb64b44364e3cd8fabc5a58a0da6841195348ca
# good: [a7fc6e39ceeeac8bdbd24f08ebb08330d15c5d33] Big drop sponsorized by AlienSkin Software ## did not compile => my bisection script assumed it was good
git bisect good a7fc6e39ceeeac8bdbd24f08ebb08330d15c5d33
# first bad commit: [adb64b44364e3cd8fabc5a58a0da6841195348ca] New docs
```

It happens when compiling colord git master with Little-CMS git master:
```
($ cd colord && ./autogen.sh && make)
  GEN      AdobeRGB1998.icc
=================================================================
==4238==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7fc76e44dc8c at pc 0x7fc774985435 bp 0x7ffe2a7a8810 sp 0x7ffe2a7a8808
READ of size 4 at 0x7fc76e44dc8c thread T0
    0 0x7fc774985434 in UnrollFloatsToFloat /home/lebedevri/src/Little-CMS/src/cmspack.c:1079
    1 0x7fc774997adf in FloatXFORM /home/lebedevri/src/Little-CMS/src/cmsxform.c:266
    2 0x7fc77499751f in cmsDoTransform /home/lebedevri/src/Little-CMS/src/cmsxform.c:189
    3 0x7fc7748dbbf0 in cd_icc_utils_get_coverage_calc /home/lebedevri/src/colord/lib/colord/cd-icc-utils.c:121
    4 0x7fc7748dbf33 in cd_icc_utils_get_coverage /home/lebedevri/src/colord/lib/colord/cd-icc-utils.c:168
    5 0x56316eed5206 in cd_util_icc_set_metadata_coverage /home/lebedevri/src/colord/client/cd-create-profile.c:677
    6 0x56316eed58aa in cd_util_create_from_xml /home/lebedevri/src/colord/client/cd-create-profile.c:757
    7 0x56316eed606f in main /home/lebedevri/src/colord/client/cd-create-profile.c:843
    8 0x7fc7722bcb44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    9 0x56316eed28b8  (/home/lebedevri/src/colord/client/.libs/cd-create-profile+0x38b8)

0x7fc76e44dc8c is located 0 bytes to the right of 431244-byte region [0x7fc76e3e4800,0x7fc76e44dc8c)
allocated by thread T0 here:
    0 0x7fc7739574e1 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x944e1)
    1 0x7fc772c125c0 in g_malloc0 (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4f5c0)
    2 0x7fc7748dbf33 in cd_icc_utils_get_coverage /home/lebedevri/src/colord/lib/colord/cd-icc-utils.c:168
    3 0x56316eed5206 in cd_util_icc_set_metadata_coverage /home/lebedevri/src/colord/client/cd-create-profile.c:677
    4 0x56316eed58aa in cd_util_create_from_xml /home/lebedevri/src/colord/client/cd-create-profile.c:757
    5 0x56316eed606f in main /home/lebedevri/src/colord/client/cd-create-profile.c:843
    6 0x7fc7722bcb44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/lebedevri/src/Little-CMS/src/cmspack.c:1079 UnrollFloatsToFloat
Shadow bytes around the buggy address:
  0x0ff96dc81b40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff96dc81b50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff96dc81b60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff96dc81b70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff96dc81b80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0ff96dc81b90: 00[04]fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0ff96dc81ba0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0ff96dc81bb0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0ff96dc81bc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0ff96dc81bd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0ff96dc81be0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==4238==ABORTING
```

In the end, it happens because outer loop variable is re-used for inner loop.
So i have fixed it by defining new loop variable and using it for innermost loop.

@mm2 please pull!