### PR TITLE
Slope Limit

### DIFF
--- a/include/lcms2.h
+++ b/include/lcms2.h
@@ -1639,6 +1639,10 @@ CMSAPI cmsUInt32Number  CMSEXPORT cmsGetSupportedIntentsTHR(cmsContext ContextID
 #define cmsFLAGS_HIGHRESPRECALC           0x0400    // Use more memory to give better accurancy
 #define cmsFLAGS_LOWRESPRECALC            0x0800    // Use less memory to minimize resouces
 
+// Slope Limit
+#define cmsFLAGS_SLOPE_LIMIT_16       0x40000000    // Enable Slope Limit 16 (emulate ColorSync & Kodak CMM)
+#define cmsFLAGS_SLOPE_LIMIT_32       0x80000000    // Enable Slope Limit 32 (emulate Adobe CMM)
+
 // For devicelink creation
 #define cmsFLAGS_8BITS_DEVICELINK         0x0008   // Create 8 bits devicelinks
 #define cmsFLAGS_GUESSDEVICECLASS         0x0020   // Guess device class (for transform2devicelink)

--- a/src/cmscnvrt.c
+++ b/src/cmscnvrt.c
@@ -536,9 +536,14 @@ cmsPipeline* DefaultICCintents(cmsContext       ContextID,
     cmsColorSpaceSignature ColorSpaceIn, ColorSpaceOut = cmsSigLabData, CurrentColorSpace;
     cmsProfileClassSignature ClassSig;
     cmsUInt32Number  i, Intent;
-
+	int SlopeLimit = 0;
+	
     // For safety
     if (nProfiles == 0) return NULL;
+
+	// Register slope limit flags
+	if (dwFlags & cmsFLAGS_SLOPE_LIMIT_16) SlopeLimit = 16;
+	else if (dwFlags & cmsFLAGS_SLOPE_LIMIT_32) SlopeLimit = 32;
 
     // Allocate an empty LUT for holding the result. 0 as channel count means 'undefined'
     Result = cmsPipelineAlloc(ContextID, 0, 0);
@@ -608,13 +613,13 @@ cmsPipeline* DefaultICCintents(cmsContext       ContextID,
 
             if (lIsInput) {
                 // Input direction means non-pcs connection, so proceed like devicelinks
-                Lut = _cmsReadInputLUT(hProfile, Intent);
+                Lut = _cmsReadInputLUT(hProfile, Intent, -SlopeLimit);	// negative slope limit means input slope limiting
                 if (Lut == NULL) goto Error;
             }
             else {
 
                 // Output direction means PCS connection. Intent may apply here
-                Lut = _cmsReadOutputLUT(hProfile, Intent);
+                Lut = _cmsReadOutputLUT(hProfile, Intent, SlopeLimit);
                 if (Lut == NULL) goto Error;
 
 
@@ -958,7 +963,7 @@ cmsPipeline* BlackPreservingKPlaneIntents(cmsContext     ContextID,
 
     // We need the input LUT of the last profile, assuming this one is responsible of
     // black generation. This LUT will be seached in inverse order.
-    bp.LabK2cmyk = _cmsReadInputLUT(hProfiles[nProfiles-1], INTENT_RELATIVE_COLORIMETRIC);
+    bp.LabK2cmyk = _cmsReadInputLUT(hProfiles[nProfiles-1], INTENT_RELATIVE_COLORIMETRIC, 0);
     if (bp.LabK2cmyk == NULL) goto Cleanup;
 
     // Get total area coverage (in 0..1 domain)

--- a/src/cmscnvrt.c
+++ b/src/cmscnvrt.c
@@ -536,14 +536,14 @@ cmsPipeline* DefaultICCintents(cmsContext       ContextID,
     cmsColorSpaceSignature ColorSpaceIn, ColorSpaceOut = cmsSigLabData, CurrentColorSpace;
     cmsProfileClassSignature ClassSig;
     cmsUInt32Number  i, Intent;
-	int SlopeLimit = 0;
-	
+    int SlopeLimit = 0;
+    
     // For safety
     if (nProfiles == 0) return NULL;
 
-	// Register slope limit flags
-	if (dwFlags & cmsFLAGS_SLOPE_LIMIT_16) SlopeLimit = 16;
-	else if (dwFlags & cmsFLAGS_SLOPE_LIMIT_32) SlopeLimit = 32;
+    // Register slope limit flags
+    if (dwFlags & cmsFLAGS_SLOPE_LIMIT_16) SlopeLimit = 16;
+    else if (dwFlags & cmsFLAGS_SLOPE_LIMIT_32) SlopeLimit = 32;
 
     // Allocate an empty LUT for holding the result. 0 as channel count means 'undefined'
     Result = cmsPipelineAlloc(ContextID, 0, 0);
@@ -613,7 +613,7 @@ cmsPipeline* DefaultICCintents(cmsContext       ContextID,
 
             if (lIsInput) {
                 // Input direction means non-pcs connection, so proceed like devicelinks
-                Lut = _cmsReadInputLUT(hProfile, Intent, -SlopeLimit);	// negative slope limit means input slope limiting
+                Lut = _cmsReadInputLUT(hProfile, Intent, -SlopeLimit);    // negative slope limit means input slope limiting
                 if (Lut == NULL) goto Error;
             }
             else {

--- a/src/cmsgamma.c
+++ b/src/cmsgamma.c
@@ -1192,14 +1192,14 @@ cmsInt32Number  CMSEXPORT cmsGetToneCurveParametricType(const cmsToneCurve* t)
 // We need accuracy this time
 cmsFloat32Number CMSEXPORT cmsEvalToneCurveFloat(const cmsToneCurve* Curve, cmsFloat32Number v)
 {
-	return _cmsEvalToneCurveFloatWithSlopeLimit(Curve, v, 0);
+    return _cmsEvalToneCurveFloatWithSlopeLimit(Curve, v, 0);
 }
 
 cmsFloat32Number _cmsEvalToneCurveFloatWithSlopeLimit(const cmsToneCurve* Curve, cmsFloat32Number v, int SlopeLimit)
 {
     _cmsAssert(Curve != NULL);
-	
-	cmsFloat32Number result;
+    
+    cmsFloat32Number result;
 
     // Check for 16 bits table. If so, this is a limited-precision tone curve
     if (Curve ->nSegments == 0) {
@@ -1211,21 +1211,21 @@ cmsFloat32Number _cmsEvalToneCurveFloatWithSlopeLimit(const cmsToneCurve* Curve,
 
         result = (cmsFloat32Number) (Out / 65535.0);
     }
-	else result = (cmsFloat32Number) EvalSegmentedFn(Curve, v);
-	
-	// Apply slope limit, if set to do so
-	if (SlopeLimit < 0) {		// < 0 means input tone curve
-		
-		cmsFloat32Number factor = (cmsFloat32Number)(-SlopeLimit);
-		result = fmaxf(result, v / factor);
-	}
-	else if (SlopeLimit > 0) {	// > 0 means output tone curve
-		
-		cmsFloat32Number factor = (cmsFloat32Number)(SlopeLimit);
-		result = fminf(result, v * factor);
-	}
-	
-	return result;
+    else result = (cmsFloat32Number) EvalSegmentedFn(Curve, v);
+    
+    // Apply slope limit, if set to do so
+    if (SlopeLimit < 0) {       // < 0 means input tone curve
+    
+        cmsFloat32Number factor = (cmsFloat32Number)(-SlopeLimit);
+        result = fmaxf(result, v / factor);
+    }
+    else if (SlopeLimit > 0) {  // > 0 means output tone curve
+        
+        cmsFloat32Number factor = (cmsFloat32Number)(SlopeLimit);
+        result = fminf(result, v * factor);
+    }
+    
+    return result;
 }
 
 // We need xput over here

--- a/src/cmslut.c
+++ b/src/cmslut.c
@@ -55,7 +55,7 @@ cmsStage* _cmsStageAllocPlaceholderWithSlopeLimit(cmsContext ContextID,
     ph ->DupElemPtr     = DupElemPtr;
     ph ->FreePtr        = FreePtr;
     ph ->Data           = Data;
-	ph ->SlopeLimit     = SlopeLimit;
+    ph ->SlopeLimit     = SlopeLimit;
 
     return ph;
 }
@@ -71,14 +71,14 @@ cmsStage* CMSEXPORT _cmsStageAllocPlaceholder(cmsContext ContextID,
                                 void*             Data)
 {
     return _cmsStageAllocPlaceholderWithSlopeLimit(ContextID,
-	                               Type,
-								   InputChannels,
-								   OutputChannels,
-								   EvalPtr,
-								   DupElemPtr,
-								   FreePtr,
-								   Data,
-								   0);
+                                   Type,
+                                   InputChannels,
+                                   OutputChannels,
+                                   EvalPtr,
+                                   DupElemPtr,
+                                   FreePtr,
+                                   Data,
+                                   0);
 }
 
 

--- a/src/cmslut.c
+++ b/src/cmslut.c
@@ -36,7 +36,7 @@ cmsStage* _cmsStageAllocPlaceholderWithSlopeLimit(cmsContext ContextID,
                                 _cmsStageEvalFn     EvalPtr,
                                 _cmsStageDupElemFn  DupElemPtr,
                                 _cmsStageFreeElemFn FreePtr,
-                                void*             Data,
+                                void*               Data,
                                 int                 SlopeLimit)
 {
     cmsStage* ph = (cmsStage*) _cmsMallocZero(ContextID, sizeof(cmsStage));
@@ -62,23 +62,23 @@ cmsStage* _cmsStageAllocPlaceholderWithSlopeLimit(cmsContext ContextID,
 
 
 cmsStage* CMSEXPORT _cmsStageAllocPlaceholder(cmsContext ContextID,
-                                cmsStageSignature Type,
-                                cmsUInt32Number InputChannels,
-                                cmsUInt32Number OutputChannels,
+                                cmsStageSignature   Type,
+                                cmsUInt32Number     InputChannels,
+                                cmsUInt32Number     OutputChannels,
                                 _cmsStageEvalFn     EvalPtr,
                                 _cmsStageDupElemFn  DupElemPtr,
                                 _cmsStageFreeElemFn FreePtr,
-                                void*             Data)
+                                void*               Data)
 {
     return _cmsStageAllocPlaceholderWithSlopeLimit(ContextID,
-                                   Type,
-                                   InputChannels,
-                                   OutputChannels,
-                                   EvalPtr,
-                                   DupElemPtr,
-                                   FreePtr,
-                                   Data,
-                                   0);
+                                    Type,
+                                    InputChannels,
+                                    OutputChannels,
+                                    EvalPtr,
+                                    DupElemPtr,
+                                    FreePtr,
+                                    Data,
+                                    0);
 }
 
 

--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -1900,6 +1900,11 @@ cmsBool _cmsOptimizePipeline(cmsContext ContextID,
         _cmsPipelineSetOptimizationParameters(*PtrLut, FastIdentity16, (void*) *PtrLut, NULL, NULL);
         return TRUE;
     }
+	
+	// Tone Curve Stages with a slope limit cannot be optimized. The following line switches off optimization
+	// completely and is a workaround until _cmsStage_struct.Implements correctly signifies that this
+	// stage cannot be optimized
+	if (*dwFlags & (cmsFLAGS_SLOPE_LIMIT_16 | cmsFLAGS_SLOPE_LIMIT_32)) *dwFlags |= cmsFLAGS_NOOPTIMIZE;
 
     // Do not optimize, keep all precision
     if (*dwFlags & cmsFLAGS_NOOPTIMIZE)

--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -1900,11 +1900,11 @@ cmsBool _cmsOptimizePipeline(cmsContext ContextID,
         _cmsPipelineSetOptimizationParameters(*PtrLut, FastIdentity16, (void*) *PtrLut, NULL, NULL);
         return TRUE;
     }
-	
-	// Tone Curve Stages with a slope limit cannot be optimized. The following line switches off optimization
-	// completely and is a workaround until _cmsStage_struct.Implements correctly signifies that this
-	// stage cannot be optimized
-	if (*dwFlags & (cmsFLAGS_SLOPE_LIMIT_16 | cmsFLAGS_SLOPE_LIMIT_32)) *dwFlags |= cmsFLAGS_NOOPTIMIZE;
+    
+    // Tone Curve Stages with a slope limit cannot be optimized. The following line switches off optimization
+    // completely and is a workaround until _cmsStage_struct.Implements correctly signifies that this
+    // stage cannot be optimized
+    if (*dwFlags & (cmsFLAGS_SLOPE_LIMIT_16 | cmsFLAGS_SLOPE_LIMIT_32)) *dwFlags |= cmsFLAGS_NOOPTIMIZE;
 
     // Do not optimize, keep all precision
     if (*dwFlags & cmsFLAGS_NOOPTIMIZE)

--- a/src/cmsps2.c
+++ b/src/cmsps2.c
@@ -1073,7 +1073,7 @@ cmsUInt32Number GenerateCSA(cmsContext ContextID,
 
 
         // Read the lut with all necessary conversion stages
-        lut = _cmsReadInputLUT(hProfile, Intent);
+        lut = _cmsReadInputLUT(hProfile, Intent, 0);
         if (lut == NULL) goto Error;
 
 

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -817,9 +817,9 @@ struct _cmsStage_struct {
 
     // A generic pointer to whatever memory needed by the stage
     void*               Data;
-	
-	// Slope limit setting for tone curves (used internally)
-	int                 SlopeLimit;
+
+    // Slope limit setting for tone curves (used internally)
+    int                 SlopeLimit;
 
     // Maintains linked list (used internally)
     struct _cmsStage_struct* Next;

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -817,6 +817,9 @@ struct _cmsStage_struct {
 
     // A generic pointer to whatever memory needed by the stage
     void*               Data;
+	
+	// Slope limit setting for tone curves (used internally)
+	int                 SlopeLimit;
 
     // Maintains linked list (used internally)
     struct _cmsStage_struct* Next;
@@ -842,6 +845,11 @@ cmsStage*        _cmsStageClipNegatives(cmsContext ContextID, int nChannels);
 
 // For curve set only
 cmsToneCurve**     _cmsStageGetPtrToCurveSet(const cmsStage* mpe);
+
+
+// Curve evaluation with slope limit
+cmsStage*          _cmsStageAllocToneCurvesWithSlopeLimit(cmsContext ContextID, cmsUInt32Number nChannels, cmsToneCurve* const Curves[], int SlopeLimit);
+cmsFloat32Number   _cmsEvalToneCurveFloatWithSlopeLimit(const cmsToneCurve* Curve, cmsFloat32Number v, int SlopeLimit);
 
 
 // Pipeline Evaluator (in floating point)
@@ -872,8 +880,8 @@ struct _cmsPipeline_struct {
 // Read tags using low-level function, provide necessary glue code to adapt versions, etc. All those return a brand new copy
 // of the LUTS, since ownership of original is up to the profile. The user should free allocated resources.
 
-cmsPipeline*      _cmsReadInputLUT(cmsHPROFILE hProfile, int Intent);
-cmsPipeline*      _cmsReadOutputLUT(cmsHPROFILE hProfile, int Intent);
+cmsPipeline*      _cmsReadInputLUT(cmsHPROFILE hProfile, int Intent, int SlopeLimit);
+cmsPipeline*      _cmsReadOutputLUT(cmsHPROFILE hProfile, int Intent, int SlopeLimit);
 cmsPipeline*      _cmsReadDevicelinkLUT(cmsHPROFILE hProfile, int Intent);
 
 // Special values


### PR DESCRIPTION
Implementation of Slope Limiting, to emulate the TRC handling of other CMMs on a per-transform basis, as discussed in the [Lcms-user mailing list](https://sourceforge.net/p/lcms/mailman/message/34954653/).

Currently, the following emulation settings are known from tests performed on Mac OS X 10.9:

| CMM | flags for `cmsCreateTransform()` and `cmsCreateTransformTHR()` | state |
| --- | --- | --- |
| Adobe CMM | `cmsFLAGS_SLOPE_LIMIT_32 | cmsFLAGS_BLACKPOINTCOMPENSATION` | confirmed for published 32 bit version from 2008 (version 1.1.0.2.15.15 for Mac OS X) |
| Apple ColorSync 32 bit | no flags | old 32 bit ColorSync API, deprecated in Mac OS X 10.6 in 2009, confirmed for the version included in Mac OS X 10.9 |
| Apple ColorSync 64 bit | `cmsFLAGS_SLOPE_LIMIT_16` | new 64 bit ColorSync API introduced in Mac OS X 10.6 in 2009, confirmed for the version included in Mac OS X 10.9 |
| Canon ColorGear CMM | no flags | confirmed for 32 bit version 2.27 for Mac OS X from 2008 |
| Kodak CMM | `cmsFLAGS_SLOPE_LIMIT_16` | unpublished on Mac OS X, according to documentation from Kodak |
