### PR TITLE
Fix memory leak in cmsIT8LoadFromMem

### DIFF
--- a/src/cmscgats.c
+++ b/src/cmscgats.c
@@ -255,7 +255,7 @@ static PROPERTY PredefinedProperties[] = {
                                // needed.
 
         {"SAMPLE_BACKING",   WRITE_STRINGIFY},   // Identifies the backing material used behind the sample during
-                               // measurement. Allowed values are “black”, “white”, or {"na".
+                               // measurement. Allowed values are Â“blackÂ”, Â“whiteÂ”, or {"na".
 
         {"CHISQ_DOF",        WRITE_STRINGIFY},   // Degrees of freedom associated with the Chi squared statistic
 
@@ -271,7 +271,7 @@ static PROPERTY PredefinedProperties[] = {
                                // denote the use of filters such as none, D65, Red, Green or Blue.
 
        {"POLARIZATION",      WRITE_STRINGIFY},   // Identifies the use of a physical polarization filter during measurement. Allowed
-                               // values are {"yes”, “white”, “none” or “na”.
+                               // values are {"yesÂ”, Â“whiteÂ”, Â“noneÂ” or Â“naÂ”.
 
        {"WEIGHTING_FUNCTION", WRITE_PAIR},   // Indicates such functions as: the CIE standard observer functions used in the
                                // calculation of various data parameters (2 degree and 10 degree), CIE standard
@@ -2314,6 +2314,8 @@ cmsHANDLE  CMSEXPORT cmsIT8LoadFromMem(cmsContext ContextID, void *Ptr, cmsUInt3
 
     if (!ParseIT8(it8, type-1)) {
 
+        _cmsFree(ContextID, it8->MemoryBlock);
+        it8 -> MemoryBlock = NULL;
         cmsIT8Free(hIT8);
         return FALSE;
     }


### PR DESCRIPTION
Before return from current function, memory pointed by it8->MemoryBlock is not freed & hence will cause memory leak.