### PR TITLE
Update FROM_16_TO_8 macro not to raise UBSan error

### DIFF
--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -101,7 +101,7 @@
 
 // A fast way to convert from/to 16 <-> 8 bits
 #define FROM_8_TO_16(rgb) (cmsUInt16Number) ((((cmsUInt16Number) (rgb)) << 8)|(rgb))
-#define FROM_16_TO_8(rgb) (cmsUInt8Number) ((((rgb) * 65281 + 8388608) >> 24) & 0xFF)
+#define FROM_16_TO_8(rgb) (cmsUInt8Number) ((((cmsUInt32Number)(rgb) * 65281U + 8388608U) >> 24) & 0xFFU)
 
 // Code analysis is broken on asserts
 #ifdef _MSC_VER


### PR DESCRIPTION
When built with Undefined Behavior Sanitizer, FROM_16_TO_8 raises signed integer overflow errors.
All operands get promoted to integer. Forcing Unsigned arithmetic gets rid of those errors.