### PR TITLE
Warnings cleanup

### DIFF
--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -1231,6 +1231,7 @@ Error:
     return FALSE;
 
     cmsUNUSED_PARAMETER(Intent);
+    cmsUNUSED_PARAMETER(lIsLinear);
 }
 
 

--- a/src/cmsplugin.c
+++ b/src/cmsplugin.c
@@ -176,9 +176,9 @@ cmsBool CMSEXPORT  _cmsReadFloat32Number(cmsIOHANDLER* io, cmsFloat32Number* n)
             return FALSE;
 
     if (n != NULL) {
-
+        cmsUInt32Number *ptmp = &tmp;
         tmp = _cmsAdjustEndianess32(tmp);
-        *n = *(cmsFloat32Number*) &tmp;
+        *n = *(cmsFloat32Number*)ptmp;
     }
     return TRUE;
 }
@@ -286,10 +286,11 @@ cmsBool CMSEXPORT  _cmsWriteUInt32Number(cmsIOHANDLER* io, cmsUInt32Number n)
 cmsBool CMSEXPORT  _cmsWriteFloat32Number(cmsIOHANDLER* io, cmsFloat32Number n)
 {
     cmsUInt32Number tmp;
+    cmsFloat32Number *pn = &n;
 
     _cmsAssert(io != NULL);
 
-    tmp = *(cmsUInt32Number*) &n;
+    tmp = *(cmsUInt32Number*)pn;
     tmp = _cmsAdjustEndianess32(tmp);
     if (io -> Write(io, sizeof(cmsUInt32Number), &tmp) != 1)
             return FALSE;

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -994,7 +994,7 @@ cmsBool  Type_Text_Description_Write(struct _cms_typehandler_struct* self, cmsIO
     }
 
     // Tell the real text len including the null terminator and padding
-    len_text = strlen(Text) + 1;
+    len_text = (cmsUInt32Number)(strlen(Text) + 1);
     // Compute an total tag size requirement
     len_tag_requirement = (8+4+len_text+4+4+2*len_text+2+1+67);
     len_aligned = _cmsALIGNLONG(len_tag_requirement);


### PR DESCRIPTION
I try to remove warnings by touching less code as possible.

gcc 5.3 and msvc 2013 warning clenup. Probabily cmsUNUSED_PARAMETER should be only cmsUNUSED (that should be created)... 
The "dereferencing type-punned" fix is not beautifull but it works. A better fix could be (not tested) a double cast by using a char\* cast.
