### PR TITLE
NO_VA_END in cmsplugin.c

### DIFF
--- a/src/cmsplugin.c
+++ b/src/cmsplugin.c
@@ -485,7 +485,10 @@ cmsBool CMSEXPORT _cmsIOPrintf(cmsIOHANDLER* io, const char* frm, ...)
     va_start(args, frm);
 
     len = vsnprintf((char*) Buffer, 2047, frm, args);
-    if (len < 0) return FALSE;   // Truncated, which is a fatal error for us
+    if (len < 0) {
+        va_end(args);
+        return FALSE;   // Truncated, which is a fatal error for us
+    }
 
     rc = io ->Write(io, len, Buffer);
 


### PR DESCRIPTION
Function 'va_start' is called at line:485. But, 'va_end' is not called before returning from function '_cmsIOPrintf()' at line:488. 
The va_end performs cleanup for the args object initialized by a call to va_start. If va_end is not called before a function that calls va_start returns, the behavior is undefined.