### PR TITLE
UNREACHABLE_CODE.TERMINATION in vprf.c

### DIFF
--- a/utils/common/vprf.c
+++ b/utils/common/vprf.c
@@ -250,17 +250,14 @@ cmsBool SaveMemoryBlock(const cmsUInt8Number* Buffer, cmsUInt32Number dwLen, con
     FILE* out = fopen(Filename, "wb");
     if (out == NULL) {
         FatalError("Cannot create '%s'", Filename);
-        return FALSE;
     }
 
     if (fwrite(Buffer, 1, dwLen, out) != dwLen) {
         FatalError("Cannot write %ld bytes to %s", dwLen, Filename);
-        return FALSE;
     }
 
     if (fclose(out) != 0) {
         FatalError("Error flushing file '%s'", Filename);
-        return FALSE;
     }
 
     return TRUE;
@@ -292,7 +289,6 @@ int PixelTypeFromChanCount(int ColorChannels)
         default:
 
             FatalError("What a weird separation of %d channels?!?!", ColorChannels);
-            return -1;
     }
 }
 
@@ -331,6 +327,5 @@ int ChanCountFromPixelType(int ColorChannels)
       default:
 
           FatalError("Unsupported color space of %d channels", ColorChannels);
-          return -1;
     }
 }

--- a/utils/jpgicc/jpgicc.c
+++ b/utils/jpgicc/jpgicc.c
@@ -105,7 +105,7 @@ in the case of future revision (for example, 1994).
 Spatial Resolution: (Two octets) Lightness pixel density in pels/25.4 mm. The basic value is 200. Allowed values are
 100, 200, 300, 400, 600 and 1200 pels/25.4 mm, with square (or equivalent) pels.
 
-NOTE – The functional equivalence of inch-based and mm-based resolutions is maintained. For example, the 200 × 200
+NOTE â€“ The functional equivalence of inch-based and mm-based resolutions is maintained. For example, the 200 Ã— 200
 */
 
 static
@@ -142,8 +142,8 @@ void SetITUFax(j_compress_ptr cinfo)
 // the default range for ITU/T.42 -- See RFC 2301, section 6.2.3 for details
 
 //  L*  =   [0, 100]
-//  a*  =   [–85, 85]
-//  b*  =   [–75, 125]
+//  a*  =   [â€“85, 85]
+//  b*  =   [â€“75, 125]
 
 
 // These functions does convert the encoding of ITUFAX to floating point
@@ -651,7 +651,6 @@ cmsUInt32Number GetInputPixelType(void)
 
      default:
               FatalError("Unsupported color space (0x%x)", Decompressor.jpeg_color_space);
-              return 0;
      }
 
      return (EXTRA_SH(extra)|CHANNELS_SH(ColorChannels)|BYTES_SH(bps)|COLORSPACE_SH(space)|FLAVOR_SH(Flavor));


### PR DESCRIPTION
Statements at line:253, line:258, line:263, line:295, line:334 are unreachable beacuse FatalError() function is called before the return statement. Program exits from FatalError() function because exit(1) is called from it.
return statement can be removed.
