### PR TITLE
UNREACHABLE_CODE.TERMINATION in linkicc.c

### DIFF
--- a/utils/linkicc/linkicc.c
+++ b/utils/linkicc/linkicc.c
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
     // How many profiles to link?
     nargs = (argc - xoptind);
     if (nargs < 1)
-        return Help(0); 
+        Help(0); 
 
     if (nargs > 255) {
         FatalError("Holy profile! what are you trying to do with so many profiles!?");


### PR DESCRIPTION
return statement at line:291 is unreachable because Program exits from Help(0) function as exit(0) is called from it.
return Help(0) can be replaced with Help(0).
