### PR TITLE
Fix writing of arbitrary chars into ColorantTable Name

### DIFF
--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -3019,6 +3019,8 @@ cmsBool  Type_ColorantTable_Write(struct _cms_typehandler_struct* self, cmsIOHAN
         char root[33];
         cmsUInt16Number PCS[3];
 
+        memset(root, 0, sizeof(root));
+
         if (!cmsNamedColorInfo(NamedColorList, i, root, NULL, NULL, PCS, NULL)) return 0;
         root[32] = 0;
 


### PR DESCRIPTION
The root array gets filled by strcpy for the count of chars until
zero terminator. The bytes after the string are undefined, but gets
written into the bytestream. Memory debuggers like valgrind complain
about use of uninitialised values. As well a written profile might
contain random bytes, which have to be tracked by the profile ID.
Tools like iccToXml might by affected.

The memset initialises the "root" array, avoids the random values and
fixes the warnings.