### PR TITLE
Fix lcms2.pc.in thread library dependency.

### DIFF
--- a/lcms2.pc.in
+++ b/lcms2.pc.in
@@ -7,5 +7,5 @@ Name: @PACKAGE@
 Description: LCMS Color Management Library
 Version: @VERSION@
 Libs: -L${libdir} -llcms2
-Libs.private: @LIB_MATH@ 
+Libs.private: @LIB_MATH@ @LIB_THREAD@
 Cflags: -I${includedir}


### PR DESCRIPTION
Needed (sometimes) for static linking (see [1], [2] and [3] for
original buildroot compile problem).

[1] http://autobuild.buildroot.net/results/5ce/5cee20afd8bef5268832cddcb3a5270746be7a57
[2] http://lists.busybox.net/pipermail/buildroot/2016-November/177187.html
[3] http://lists.busybox.net/pipermail/buildroot/2016-November/177188.html

Signed-off-by: Peter Seiderer <ps.report@gmx.net>