### PR TITLE
Fix windows static builds

### DIFF
--- a/include/lcms2.h
+++ b/include/lcms2.h
@@ -230,6 +230,9 @@ typedef int                  cmsBool;
 #           define CMSAPI     __declspec(dllimport)
 #        endif
 #     endif
+#  else
+#     define CMSEXPORT
+#     define CMSAPI
 #  endif
 #else  // not Windows
 #  ifdef HAVE_FUNC_ATTRIBUTE_VISIBILITY


### PR DESCRIPTION
After the latest changes CMSEXPORT and CMSAPI were undefined for Windows static (non-DLL) builds.