### PR TITLE
Fixed incorrect 16 to 8 bit conversion in MatShaperEval16 function.

### DIFF
--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -1522,11 +1522,10 @@ void MatShaperEval16(register const cmsUInt16Number In[],
     cmsS1Fixed14Number l1, l2, l3, r, g, b;
     cmsUInt32Number ri, gi, bi;
 
-    // In this case (and only in this case!) we can use this simplification since
-    // In[] is assured to come from a 8 bit number. (a << 8 | a)
-    ri = In[0] & 0xFF;
-    gi = In[1] & 0xFF;
-    bi = In[2] & 0xFF;
+    // Extract the most significant 8-bits
+    ri = (In[0] >> 8) & 0xFF;
+    gi = (In[1] >> 8) & 0xFF;
+    bi = (In[2] >> 8) & 0xFF;
 
     // Across first shaper, which also converts to 1.14 fixed point
     r = p->Shaper1R[ri];


### PR DESCRIPTION
The `MatShaperEval16` function makes an assumption that 8-bit values were converted to 16-bit using the `FROM_8_TO_16` macro. That is, the lower and upper 8-bits are replicated across the entire output word:

```c
cmsUInt16Number outValue = (cmsUInt16Number)(inValue << 8) | inValue; // inValue is 8-bit
```

And thus the `MatShaperEval16` function [extracts only the lower 8-bits](https://github.com/mm2/Little-CMS/blob/master/src/cmsopt.c#L1527) of the input word when applying the matrix-shaper evaluator. However, the aforementioned assumption breaks down when custom input formatter plugins are used, because the lower 8-bits may be padded in a different way. The correct approach is to extract the most significant 8-bits from the input word:

```cpp
ri = (In[0] >> 8) & 0xFF;
gi = (In[1] >> 8) & 0xFF;
bi = (In[2] >> 8) & 0xFF;
```

The following C++14 code demonstrates the use of a custom formatter plugin, which reproduces the bug in the `MatShaperEval16` function: 

```cpp
#include <array>
#include <iostream>
#include <lcms2.h>
#include <lcms2_plugin.h>

constexpr auto convert8to16(const cmsUInt8Number inC) -> cmsUInt16Number
   {
   //We simply pad all lower 8-bits to either 1 or 0 depending on input LSB
   return (static_cast<cmsUInt16Number>( inC ) << 8) | static_cast<cmsUInt16Number>( inC & 1 ? 0xFF : 0x00 );
   }

static auto inputFormatterCallbackRGB8(_cmstransform_struct* transform, cmsUInt16Number* output, cmsUInt8Number* imageBuffer, cmsUInt32Number stride) -> cmsUInt8Number*
   {
   output[0] = convert8to16(imageBuffer[0]);
   output[1] = convert8to16(imageBuffer[1]);
   output[2] = convert8to16(imageBuffer[2]);

   return imageBuffer + sizeof(cmsUInt8Number) * 3;
   }

static auto formatterFactoryCallback(cmsUInt32Number cmsFormat, cmsFormatterDirection direction, cmsUInt32Number flags) -> cmsFormatter
   {
   if (cmsFormat == TYPE_RGB_8 && direction == cmsFormatterInput && (flags & CMS_PACK_FLAGS_FLOAT) == 0)
      {
      return { inputFormatterCallbackRGB8 };
      }

   return { nullptr };
   }

auto makeFormatterPlugin() -> cmsPluginFormatters
   {
   auto plugin = cmsPluginFormatters{};

   plugin.base = { cmsPluginMagicNumber, 2000, cmsPluginFormattersSig, nullptr };

   plugin.FormattersFactory = formatterFactoryCallback;

   return plugin;
   }

auto makeProfileAdobeRGB1998(cmsContext context) -> cmsHPROFILE
   {
   auto* toneCurve = cmsBuildGamma(context, 563.0 / 256.0);

   cmsToneCurve* toneCurves[3] = { toneCurve, toneCurve, toneCurve };

   auto whitePoint = cmsCIExyY{ 0.31271, 0.32902, 1 };
   auto primaries = cmsCIExyYTRIPLE
      {
      cmsCIExyY{ 0.64000, 0.33000, 1 },  //red
      cmsCIExyY{ 0.21000, 0.71000, 1 },  //green
      cmsCIExyY{ 0.15000, 0.06000, 1 }   //blue
      };

   auto* profile = cmsCreateRGBProfileTHR(context, &whitePoint, &primaries, toneCurves);

   cmsFreeToneCurve(toneCurve);

   return profile;
   }

int main(int argc, const char * argv[])
   {
   auto* context = cmsCreateContext(nullptr, nullptr);

   auto plugin = makeFormatterPlugin();
   cmsPluginTHR(context, &plugin); //Comment this out to disable custom plugin

   auto* profileAdobeRGB1998 = makeProfileAdobeRGB1998(context);
   auto* profileSRGB = cmsCreate_sRGBProfileTHR(context);
   auto* transform = cmsCreateTransformTHR(context, profileAdobeRGB1998, TYPE_RGB_8, profileSRGB, TYPE_RGB_FLT, INTENT_ABSOLUTE_COLORIMETRIC, 0);

   auto inBuffer = std::array<uint8_t, 9>{{ 0x7F, 0x7F, 0x7F,  0x7E, 0x7E, 0x7E,  0x03, 0x03, 0x03 }};
   auto outBuffer = std::array<float, 9>{{ 0, 0, 0,  0, 0, 0,  0, 0, 0 }};

   cmsDoTransform(transform, inBuffer.data(), outBuffer.data(), 3);

   std::cout << "Input Buffer: ";
   std::copy(inBuffer.begin(), inBuffer.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << '\n';
   std::cout << "Output Buffer: ";
   std::copy(outBuffer.begin(), outBuffer.end(), std::ostream_iterator<float>(std::cout, " "));
   std::cout << '\n';

   cmsDeleteTransform(transform);
   cmsCloseProfile(profileSRGB);
   cmsCloseProfile(profileAdobeRGB1998);
   cmsDeleteContext(context);

   return 0;
   }
```

The code snippet should produce the following result:

Results with formatter plugin disabled:

	Input Buffer: 127 127 127 126 126 126 3 3 3 
	Output Buffer: 0.501976 0.501976 0.501976 0.497963 0.497963 0.497963 0.000793469 0.000793469 0.000793469 

Results with formatter plugin enabled:

	Input Buffer: 127 127 127 126 126 126 3 3 3 
	Output Buffer: 1 1 1 0 0 0 1 1 1 

Results with the fix and the formatter plugin enabled:

	Input Buffer: 127 127 127 126 126 126 3 3 3 
	Output Buffer: 0.501976 0.501976 0.501976 0.497963 0.497963 0.497963 0.000793469 0.000793469 0.000793469 
