### PR TITLE
Ensure any open ICC profile file handles are closed on exec

### DIFF
--- a/src/cmsio0.c
+++ b/src/cmsio0.c
@@ -385,7 +385,7 @@ cmsIOHANDLER* CMSEXPORT cmsOpenIOhandlerFromFile(cmsContext ContextID, const cha
     switch (*AccessMode) {
 
     case 'r':
-        fm = fopen(FileName, "rb");
+        fm = fopen(FileName, "rbe");
         if (fm == NULL) {
             _cmsFree(ContextID, iohandler);
              cmsSignalError(ContextID, cmsERROR_FILE, "File '%s' not found", FileName);


### PR DESCRIPTION
Hello, thank you for all the continued great work on the ever-useful Little CMS.

You may be aware that lcms2 is used by [libvips](https://github.com/jcupitt/libvips), which in turn is used by [sharp](https://github.com/lovell/sharp).

I've had reports that if a process using sharp and therefore lcms2 spawns a child process via exec, that process appears to inherit any lcms-opened file handles - see https://github.com/lovell/sharp/issues/674#issuecomment-289832272 for the background.

This PR ensures any file handles opened by lcms2 for reading are closed on exec using the `e` flag of `fopen`, available since glibc 2.7 (e.g. Ubuntu 8.04). I haven't been able to test this on Windows or *BSD, but I believe the former and (recent versions of) the latter should ignore this.

I've not added the `e` flag to files opened for write purposes as I suspect that a much less common use case, although I'd be happy to update this PR if you'd prefer a consistent approach.

Cheers,
Lovell