### PR TITLE
Fix compilation on VS2012

### DIFF
--- a/Projects/VC2012/lcms2_DLL/lcms2_DLL.vcxproj
+++ b/Projects/VC2012/lcms2_DLL/lcms2_DLL.vcxproj
@@ -206,6 +206,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\src\cmsalpha.c" />
     <ClCompile Include="..\..\..\src\cmscam02.c" />
     <ClCompile Include="..\..\..\src\cmscgats.c" />
     <ClCompile Include="..\..\..\src\cmscnvrt.c" />

--- a/Projects/VC2012/lcms2_static/lcms2_static.vcxproj
+++ b/Projects/VC2012/lcms2_static/lcms2_static.vcxproj
@@ -168,6 +168,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\src\cmsalpha.c" />
     <ClCompile Include="..\..\..\src\cmscam02.c" />
     <ClCompile Include="..\..\..\src\cmscgats.c" />
     <ClCompile Include="..\..\..\src\cmscnvrt.c" />

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -98,10 +98,13 @@
 # endif
 
 /// Properly defien some macros to accommodate
-/// older versions of MSVC.
-#include <float.h>
-#define isnan _isnan
-#define isinf(x) (!_finite((x)))
+/// Visual Studio 2012 (MSVC 11)
+# if _MSC_VER == 1700
+#   include <float.h>
+#   define isnan _isnan
+#   define isinf(x) (!_finite((x)))
+# endif
+
 #endif
 
 

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -96,6 +96,12 @@
 # ifndef vsnprintf
 #       define vsnprintf  _vsnprintf
 # endif
+
+/// Properly defien some macros to accommodate
+/// older versions of MSVC.
+#include <float.h>
+#define isnan _isnan
+#define isinf(x) (!_finite((x)))
 #endif
 
 


### PR DESCRIPTION
Simple matter of a few #defines and a missing .c file. Fixes #125.