### PR TITLE
Fix compilation on older versions of MSVC

### DIFF
--- a/Projects/VC2012/lcms2_DLL/lcms2_DLL.vcxproj
+++ b/Projects/VC2012/lcms2_DLL/lcms2_DLL.vcxproj
@@ -206,6 +206,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\src\cmsalpha.c" />
     <ClCompile Include="..\..\..\src\cmscam02.c" />
     <ClCompile Include="..\..\..\src\cmscgats.c" />
     <ClCompile Include="..\..\..\src\cmscnvrt.c" />

--- a/Projects/VC2012/lcms2_static/lcms2_static.vcxproj
+++ b/Projects/VC2012/lcms2_static/lcms2_static.vcxproj
@@ -168,6 +168,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\src\cmsalpha.c" />
     <ClCompile Include="..\..\..\src\cmscam02.c" />
     <ClCompile Include="..\..\..\src\cmscgats.c" />
     <ClCompile Include="..\..\..\src\cmscnvrt.c" />

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -96,6 +96,12 @@
 # ifndef vsnprintf
 #       define vsnprintf  _vsnprintf
 # endif
+
+/// Properly defien some macros to accommodate
+/// older versions of MSVC.
+#include <float.h>
+#define isnan _isnan
+#define isinf(x) (!_finite((x)))
 #endif
 
 

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -97,13 +97,15 @@
 #       define vsnprintf  _vsnprintf
 # endif
 
-/// Properly defien some macros to accommodate
-/// older versions of MSVC.
-#include <float.h>
-#define isnan _isnan
-#define isinf(x) (!_finite((x)))
-#endif
+/// Properly define some macros to accommodate
+/// older MSVC versions.
+# if _MSC_VER <= 1700
+        #include <float.h>
+        #define isnan _isnan
+        #define isinf(x) (!_finite((x)))
+# endif
 
+#endif
 
 // A fast way to convert from/to 16 <-> 8 bits
 #define FROM_8_TO_16(rgb) (cmsUInt16Number) ((((cmsUInt16Number) (rgb)) << 8)|(rgb))


### PR DESCRIPTION
Simple fix adds a file to the project and applies some #defines for older header files. Fixes #126.