### PR TITLE
Fix fopen() memory leak

### DIFF
--- a/src/cmscgats.c
+++ b/src/cmscgats.c
@@ -256,7 +256,7 @@ static PROPERTY PredefinedProperties[] = {
                                                    // needed.
 
         {"SAMPLE_BACKING",   WRITE_STRINGIFY},     // Identifies the backing material used behind the sample during
-                                                   // measurement. Allowed values are “black”, “white”, or {"na".
+                                                   // measurement. Allowed values are Â“blackÂ”, Â“whiteÂ”, or {"na".
                                                   
         {"CHISQ_DOF",        WRITE_STRINGIFY},     // Degrees of freedom associated with the Chi squared statistic
                                                    // below properties are new in recent specs:
@@ -271,7 +271,7 @@ static PROPERTY PredefinedProperties[] = {
                                                    // denote the use of filters such as none, D65, Red, Green or Blue.
                                                   
        {"POLARIZATION",      WRITE_STRINGIFY},     // Identifies the use of a physical polarization filter during measurement. Allowed
-                                                   // values are {"yes”, “white”, “none” or “na”.
+                                                   // values are {"yesÂ”, Â“whiteÂ”, Â“noneÂ” or Â“naÂ”.
 
        {"WEIGHTING_FUNCTION", WRITE_PAIR},         // Indicates such functions as: the CIE standard observer functions used in the
                                                    // calculation of various data parameters (2 degree and 10 degree), CIE standard
@@ -936,6 +936,9 @@ void InSymbol(cmsIT8* it8)
                         SynError(it8, "File %s not found", FileNest->FileName);
                         return;
                 }
+                if (fclose(FileNest->Stream) != 0)
+                        return;
+            
                 it8->IncludeSP++;
 
                 it8 ->ch = ' ';


### PR DESCRIPTION
after fopen() , fclose() is not done so fd will remain open, hence will cause memory leak.