### PR TITLE
Constify some big arrays to allow to compiler put them in read only section.

### DIFF
--- a/src/cmspack.c
+++ b/src/cmspack.c
@@ -2907,7 +2907,7 @@ cmsUInt8Number* PackHalfFromFloat(_cmsTRANSFORM* info,
 // ----------------------------------------------------------------------------------------------------------------
 
 
-static cmsFormatters16 InputFormatters16[] = {
+static const cmsFormatters16 InputFormatters16[] = {
 
     //    Type                                          Mask                  Function
     //  ----------------------------   ------------------------------------  ----------------------------
@@ -2978,7 +2978,7 @@ static cmsFormatters16 InputFormatters16[] = {
 
 
 
-static cmsFormattersFloat InputFormattersFloat[] = {
+static const cmsFormattersFloat InputFormattersFloat[] = {
 
     //    Type                                          Mask                  Function
     //  ----------------------------   ------------------------------------  ----------------------------
@@ -3041,7 +3041,7 @@ cmsFormatter _cmsGetStockInputFormatter(cmsUInt32Number dwInput, cmsUInt32Number
     return fr;
 }
 
-static cmsFormatters16 OutputFormatters16[] = {
+static const cmsFormatters16 OutputFormatters16[] = {
     //    Type                                          Mask                  Function
     //  ----------------------------   ------------------------------------  ----------------------------
 

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -5293,7 +5293,7 @@ void Type_Dictionary_Free(struct _cms_typehandler_struct* self, void* Ptr)
 
 
 // This is the list of built-in types
-static _cmsTagTypeLinkedList SupportedTagTypes[] = {
+static const _cmsTagTypeLinkedList SupportedTagTypes[] = {
 
 {TYPE_HANDLER(cmsSigChromaticityType,          Chromaticity),        &SupportedTagTypes[1] },
 {TYPE_HANDLER(cmsSigColorantOrderType,         ColorantOrderType),   &SupportedTagTypes[2] },
@@ -5432,7 +5432,7 @@ typedef struct _cmsTagLinkedList_st {
 } _cmsTagLinkedList;
 
 // This is the list of built-in tags
-static _cmsTagLinkedList SupportedTags[] = {
+static const _cmsTagLinkedList SupportedTags[] = {
 
     { cmsSigAToB0Tag,               { 1, 3,  { cmsSigLut16Type,  cmsSigLutAtoBType, cmsSigLut8Type}, DecideLUTtypeA2B}, &SupportedTags[1]},
     { cmsSigAToB1Tag,               { 1, 3,  { cmsSigLut16Type,  cmsSigLutAtoBType, cmsSigLut8Type}, DecideLUTtypeA2B}, &SupportedTags[2]},

--- a/src/cmswtpnt.c
+++ b/src/cmswtpnt.c
@@ -101,7 +101,7 @@ typedef struct {
 
     } ISOTEMPERATURE;
 
-static ISOTEMPERATURE isotempdata[] = {
+static const ISOTEMPERATURE isotempdata[] = {
 //  {Mirek, Ut,       Vt,      Tt      }
     {0,     0.18006,  0.26352,  -0.24341},
     {10,    0.18066,  0.26589,  -0.25479},


### PR DESCRIPTION
Hi,

Pretty small change I had locally for a long time. Just marks some constant arrays as const letting compiler put them in r/o section. 

Regards,
Kacper