### PR TITLE
src/cmsnamed.c: fix Multilocalized test on big-endian platform

### DIFF
--- a/src/cmsnamed.c
+++ b/src/cmsnamed.c
@@ -185,26 +185,17 @@ static
 cmsUInt16Number strTo16(const char str[3])
 {
     const cmsUInt8Number* ptr8 = (const cmsUInt8Number*)str;
-    cmsUInt16Number n = (cmsUInt16Number) (((cmsUInt16Number) ptr8[1] << 8) | ptr8[0]);
+    cmsUInt16Number n = (cmsUInt16Number) (((cmsUInt16Number) ptr8[0] << 8) | ptr8[1]);
 
-    return _cmsAdjustEndianess16(n);
+    return n;
 }
 
 static
 void strFrom16(char str[3], cmsUInt16Number n)
 {
-    // Assuming this would be aligned
-    union {
-
-       cmsUInt16Number n;
-       cmsUInt8Number str[2];
-       
-    } c;
-
-    c.n = _cmsAdjustEndianess16(n);  
-
-    str[0] = (char) c.str[0]; str[1] = (char) c.str[1]; str[2] = (char) 0;
-
+    str[0] = (char) (n >> 8);
+    str[1] = (char) n;
+    str[2] = (char) 0;
 }
 
 // Add an ASCII entry. Do not add any \0 termination (ICC1v43_2010-12.pdf page 61)


### PR DESCRIPTION
Noticed single test failure on pwerpc64, powerpc and PA-RISC
(all plaforms are big-endian):

```
Checking Multilocalized profile ...FAIL!
Multilocalized profile:
```

It's caused by endianness-depedent result of
strTo16 / strFrom16 functions.

Tweaked those functions to always construct
big-endian Country and Language codes.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>