### PR TITLE
Reindent some lines, fixing gcc indentation warnings.

### DIFF
--- a/src/cmsintrp.c
+++ b/src/cmsintrp.c
@@ -935,9 +935,9 @@ void Eval4Inputs(register const cmsUInt16Number Input[],
                                 c1 = c2 = c3 = 0;
                             }
 
-                            Rest = c1 * rx + c2 * ry + c3 * rz;
+        Rest = c1 * rx + c2 * ry + c3 * rz;
 
-                            Tmp1[OutChan] = (cmsUInt16Number)(c0 + ROUND_FIXED_TO_INT(_cmsToFixedDomain(Rest)));
+        Tmp1[OutChan] = (cmsUInt16Number)(c0 + ROUND_FIXED_TO_INT(_cmsToFixedDomain(Rest)));
     }
 
 
@@ -999,9 +999,9 @@ void Eval4Inputs(register const cmsUInt16Number Input[],
                                 c1 = c2 = c3 = 0;
                             }
 
-                            Rest = c1 * rx + c2 * ry + c3 * rz;
+        Rest = c1 * rx + c2 * ry + c3 * rz;
 
-                            Tmp2[OutChan] = (cmsUInt16Number) (c0 + ROUND_FIXED_TO_INT(_cmsToFixedDomain(Rest)));
+        Tmp2[OutChan] = (cmsUInt16Number) (c0 + ROUND_FIXED_TO_INT(_cmsToFixedDomain(Rest)));
     }
 
 

--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -523,10 +523,10 @@ cmsBool  PatchLUT(cmsStage* CLUT, cmsUInt16Number At[], cmsUInt16Number Value[],
                 return FALSE;
             }
 
-            for (i = 0; i < (int) nChannelsOut; i++)
-                Grid->Tab.T[index + i] = Value[i];
+    for (i = 0; i < (int) nChannelsOut; i++)
+        Grid->Tab.T[index + i] = Value[i];
 
-            return TRUE;
+    return TRUE;
 }
 
 // Auxiliary, to see if two values are equal or very different
@@ -991,8 +991,8 @@ void PrelinEval8(register const cmsUInt16Number Input[],
                                 c1 = c2 = c3 = 0;
                             }
 
-                            Rest = c1 * rx + c2 * ry + c3 * rz + 0x8001;
-                            Output[OutChan] = (cmsUInt16Number) (c0 + ((Rest + (Rest >> 16)) >> 16));
+        Rest = c1 * rx + c2 * ry + c3 * rz + 0x8001;
+        Output[OutChan] = (cmsUInt16Number) (c0 + ((Rest + (Rest >> 16)) >> 16));
 
     }
 }

--- a/src/cmsps2.c
+++ b/src/cmsps2.c
@@ -982,7 +982,7 @@ int WriteInputMatrixShaper(cmsIOHANDLER* m, cmsHPROFILE hProfile, cmsStage* Matr
             return 0;
         }
 
-        return rc;
+    return rc;
 }
 
 

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -2394,7 +2394,7 @@ cmsStage* ReadCLUT(struct _cms_typehandler_struct* self, cmsIOHANDLER* io,
             return NULL;
         }
 
-        return CLUT;
+    return CLUT;
 }
 
 static
@@ -2678,9 +2678,9 @@ cmsBool WriteCLUT(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsUIn
             return FALSE;
         }
 
-        if (!_cmsWriteAlignment(io)) return FALSE;
+    if (!_cmsWriteAlignment(io)) return FALSE;
 
-        return TRUE;
+    return TRUE;
 }
 
 

--- a/src/cmswtpnt.c
+++ b/src/cmswtpnt.c
@@ -75,19 +75,19 @@ cmsBool  CMSEXPORT cmsWhitePointFromTemp(cmsCIExyY* WhitePoint, cmsFloat64Number
             return FALSE;
         }
 
-        // Obtain y(x)
-        y = -3.000*(x*x) + 2.870*x - 0.275;
+    // Obtain y(x)
+    y = -3.000*(x*x) + 2.870*x - 0.275;
 
-        // wave factors (not used, but here for futures extensions)
+    // wave factors (not used, but here for futures extensions)
 
-        // M1 = (-1.3515 - 1.7703*x + 5.9114 *y)/(0.0241 + 0.2562*x - 0.7341*y);
-        // M2 = (0.0300 - 31.4424*x + 30.0717*y)/(0.0241 + 0.2562*x - 0.7341*y);
+    // M1 = (-1.3515 - 1.7703*x + 5.9114 *y)/(0.0241 + 0.2562*x - 0.7341*y);
+    // M2 = (0.0300 - 31.4424*x + 30.0717*y)/(0.0241 + 0.2562*x - 0.7341*y);
 
-        WhitePoint -> x = x;
-        WhitePoint -> y = y;
-        WhitePoint -> Y = 1.0;
+    WhitePoint -> x = x;
+    WhitePoint -> y = y;
+    WhitePoint -> Y = 1.0;
 
-        return TRUE;
+    return TRUE;
 }
 
 


### PR DESCRIPTION
LittleCMS now compiles without warnings using:
CFLAGS=-Wall ./configure && make