### PR TITLE
Fix double free of curve data structure.

### DIFF
--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -1438,27 +1438,26 @@ cmsBool OptimizeByJoiningCurves(cmsPipeline** Lut, cmsUInt32Number Intent, cmsUI
 
     // Maybe the curves are linear at the end
     if (!AllCurvesAreLinear(ObtainedCurves)) {
+       _cmsStageToneCurvesData* Data;
 
         if (!cmsPipelineInsertStage(Dest, cmsAT_BEGIN, ObtainedCurves))
             goto Error;
+        Data = (_cmsStageToneCurvesData*) cmsStageData(ObtainedCurves);
+        ObtainedCurves = NULL;
 
         // If the curves are to be applied in 8 bits, we can save memory
         if (_cmsFormatterIs8bit(*InputFormat)) {
-
-            _cmsStageToneCurvesData* Data = (_cmsStageToneCurvesData*) ObtainedCurves ->Data;
              Curves16Data* c16 = CurvesAlloc(Dest ->ContextID, Data ->nCurves, 256, Data ->TheCurves);
 
-             if (c16 == NULL) goto Error; 
+             if (c16 == NULL) goto Error;
              *dwFlags |= cmsFLAGS_NOCACHE;
             _cmsPipelineSetOptimizationParameters(Dest, FastEvaluateCurves8, c16, CurvesFree, CurvesDup);
 
         }
         else {
-
-            _cmsStageToneCurvesData* Data = (_cmsStageToneCurvesData*) cmsStageData(ObtainedCurves);
              Curves16Data* c16 = CurvesAlloc(Dest ->ContextID, Data ->nCurves, 65536, Data ->TheCurves);
 
-             if (c16 == NULL) goto Error; 
+             if (c16 == NULL) goto Error;
              *dwFlags |= cmsFLAGS_NOCACHE;
             _cmsPipelineSetOptimizationParameters(Dest, FastEvaluateCurves16, c16, CurvesFree, CurvesDup);
         }


### PR DESCRIPTION
When the call to CurvesAlloc() fails in OptimizeByJoiningCurves()
the cleanup code will try to free the ObtainedCurves twice. This
is because ObtainedCurves has also been inserted into the
pipeline by the call to cmsPipelineInsertStage().

This commit NULLs the ObtainedCurves variable immediately after
the insertion into the pipeline was succesful and also moves
later use of ObtainedCurves earlier to compensate for setting
ObtainedCurves to NULL. This avoids the double free.