### PR TITLE
Buffer overflow fix.

### DIFF
--- a/src/cmsps2.c
+++ b/src/cmsps2.c
@@ -1414,7 +1414,7 @@ int WriteNamedColorCRD(cmsIOHANDLER* m, cmsHPROFILE hNamedColor, cmsUInt32Number
     cmsUInt32Number i, nColors, nColorant;
     cmsUInt32Number OutputFormat;
     char ColorName[cmsMAX_PATH];
-    char Colorant[128];
+    char Colorant[512];
     cmsNAMEDCOLORLIST* NamedColorList;
 
 


### PR DESCRIPTION
BuildColorantList() concatenates 32 bit data in each iteration. The max value of iteration can be 16.
Thus buffer overflow can occur with storage of 128 bytes. It would need 512 bytes in worst case.