### PR TITLE
Preserve trailing null

### DIFF
--- a/src/cmscgats.c
+++ b/src/cmscgats.c
@@ -1572,7 +1572,7 @@ void WriteStr(SAVESTREAM* f, const char *str)
         str = " ";
 
     // Length to write
-    len = (cmsUInt32Number) strlen(str);
+    len = (cmsUInt32Number) strlen(str) + 1;
     f ->Used += len;
 
 


### PR DESCRIPTION
Write the trailing null chracter also on stream or on memory.