### PR TITLE
Fix ifdef that protects adding sinf/sqrtf

### DIFF
--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -47,7 +47,7 @@
 #endif
 
 // BorlandC 5.5, VC2003 are broken on that
-#if defined(__BORLANDC__) || (_MSC_VER < 1400) // 1400 == VC++ 8.0
+#if defined(__BORLANDC__) || (defined(_MSC_VER) && (_MSC_VER < 1400)) // 1400 == VC++ 8.0
 #define sinf(x) (float)sin((float)x)
 #define sqrtf(x) (float)sqrt((float)x)
 #endif


### PR DESCRIPTION
Doing #if (THING < 1400) is true when THING is undefined
so we first need to check if THING is defined