### PR TITLE
cmsalpha.c : fix broken behavior on 16-bit SE 

### DIFF
--- a/src/cmsalpha.c
+++ b/src/cmsalpha.c
@@ -356,15 +356,16 @@ int FormatterPos(cmsUInt32Number frm)
     if (b == 4 && T_FLOAT(frm))
         return 4; // FLT
     if (b == 2 && !T_FLOAT(frm))
-        return 1; // 16
+		if (T_ENDIAN16(frm))
+			return 2; // 16SE
+		else
+			return 1; // 16
     if (b == 1 && !T_FLOAT(frm))
         return 0; // 8
-    if (b == 2 && T_ENDIAN16(frm))
-        return 3;
     return -1; // not recognized
 }
 
-// Obtains a alpha-to-alpha funmction formatter
+// Obtains an alpha-to-alpha function formatter
 static
 cmsFormatterAlphaFn _cmsGetFormatterAlpha(cmsContext id, cmsUInt32Number in, cmsUInt32Number out)
 {


### PR DESCRIPTION
(This was originally reported in #162.)

Without this fix, FormatterPos() is broken for 16SE requests.  (Note that no case returns `2`, the index into the 16SE row!)

Fix is simple: when 2-bytes are requested, but half-float is not, check endianness.  If T_ENDIAN16, return 16SE; otherwise, return 16.

(Also a minor typo fix on a neighboring comment.)