### PR TITLE
Fix library version for cmsGetToneCurveParams

### DIFF
--- a/configure
+++ b/configure
@@ -2406,9 +2406,9 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 #  6. If any interfaces have been removed since the last public release,
 #     then set age to 0.
 #
-LIBRARY_CURRENT=2
-LIBRARY_REVISION=10
-LIBRARY_AGE=0
+LIBRARY_CURRENT=3
+LIBRARY_REVISION=0
+LIBRARY_AGE=1
 
 
 # Obtain system type by running config.guess

--- a/configure.ac
+++ b/configure.ac
@@ -33,9 +33,9 @@ AC_CONFIG_MACRO_DIR([m4])
 #  6. If any interfaces have been removed since the last public release,
 #     then set age to 0.
 #
-LIBRARY_CURRENT=2
-LIBRARY_REVISION=10
-LIBRARY_AGE=0
+LIBRARY_CURRENT=3
+LIBRARY_REVISION=0
+LIBRARY_AGE=1
 
 AC_SUBST(LIBRARY_CURRENT)dnl
 AC_SUBST(LIBRARY_REVISION)dnl


### PR DESCRIPTION
Commit cb737b0fde11fcbb4b5cac00801f96284cf6f26d added a new
function just before the 2.11 release. But the release didn't
update the library version, so just do this to be 2.1.0.