### PR TITLE
fast_float autoconf/automake build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ PACKAGE_NAME = @PACKAGE_NAME@
 PACKAGE_VERSION = @PACKAGE_VERSION@
 
 # Directories containing Makefiles to 'make'
-SUBDIRS = src include utils/tificc utils/transicc utils/linkicc utils/jpgicc utils/psicc testbed
+SUBDIRS = src include utils/tificc utils/transicc utils/linkicc utils/jpgicc utils/psicc testbed plugins
 
 # Additional files to distribute
 EXTRA_DIST = AUTHORS COPYING ChangeLog doc Projects include bin Lib INSTALL README.1ST autogen.sh lcms2.pc.in plugins

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,8 @@ AC_LIBTOOL_SETUP
 AC_PROG_LIBTOOL
 AC_SUBST(LIBTOOL_DEPS)
 
+LIB_PLUGINS = ''
+
 # Add configure option --enable-maintainer-mode which enables dependency
 # checking and generation useful to package maintainers.  This is made an
 # option to avoid confusing end users.
@@ -137,6 +139,17 @@ AC_ARG_WITH(zlib,
 	      [  --without-zlib          disable ZLIB support],
 	      [with_zlib=$withval],
 	      [with_zlib='yes'])
+
+#fast_float plugin:
+AC_ARG_WITH(fastfloat,
+            [  --with-fastfloat  build and install fast_float plugin, use only if GPL 3.0 is acceptable],
+            [
+                with_fastfloat='yes'
+                LIB_PLUGINS="$LIB_PLUGINS -llcms2_fast_float"
+            ],
+            [
+                with_fastfloat='no'
+            ])
 
 #
 # Determine POSIX threads settings
@@ -354,6 +367,9 @@ LCMS_LIB_DEPLIBS="$LIB_MATH $LIB_THREAD"
 LCMS_LIB_DEPLIBS=`echo $LCMS_LIB_DEPLIBS | sed -e 's/  */ /g'`
 AC_SUBST(LCMS_LIB_DEPLIBS)
 
+echo "LIB_PLUGINS: $LIB_PLUGINS"
+AC_SUBST(LIB_PLUGINS)
+
 # Libraries that the jpegicc program depends on
 JPEGICC_DEPLIBS="$LIB_JPEG $LIB_MATH $LIB_THREAD"
 JPEGICC_DEPLIBS=`echo $JPEGICC_DEPLIBS | sed -e 's/  */ /g'`
@@ -379,4 +395,10 @@ AC_CONFIG_FILES([utils/linkicc/Makefile])
 AC_CONFIG_FILES([utils/jpgicc/Makefile])
 AC_CONFIG_FILES([utils/psicc/Makefile])
 AC_CONFIG_FILES([testbed/Makefile])
+if [ test "x$with_fastfloat" = "xyes" ]; then
+	AC_CONFIG_FILES([plugins/Makefile])
+	AC_CONFIG_FILES([plugins/fast_float/Makefile])
+	AC_CONFIG_FILES([plugins/fast_float/src/Makefile])
+	AC_CONFIG_FILES([plugins/fast_float/include/Makefile])
+fi
 AC_OUTPUT

--- a/lcms2.pc.in
+++ b/lcms2.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: @PACKAGE@
 Description: LCMS Color Management Library
 Version: @VERSION@
-Libs: -L${libdir} -llcms2
+Libs: -L${libdir} -llcms2 @LIB_PLUGINS@
 Libs.private: @LIB_MATH@ @LIB_THREAD@
 Cflags: -I${includedir}

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = fast_float

--- a/plugins/fast_float/Makefile.am
+++ b/plugins/fast_float/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = src include

--- a/plugins/fast_float/src/Makefile.am
+++ b/plugins/fast_float/src/Makefile.am
@@ -14,7 +14,7 @@ LIBRARY_CURRENT    = 1
 LIBRARY_REVISION   = 1
 LIBRARY_AGE        = 0
 
-INCLUDES = -I$(top_builddir)/include -I$(top_srcdir)/include -I$(srcdir)/../include -I$(builddir)/../include
+AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include -I$(srcdir)/../include -I$(builddir)/../include
 
 liblcms2_fast_float_la_LDFLAGS = -no-undefined \
   -version-info $(LIBRARY_CURRENT):$(LIBRARY_REVISION):$(LIBRARY_AGE)
@@ -24,5 +24,4 @@ liblcms2_fast_float_la_LIBADD = $(LCMS_LIB_DEPLIBS) $(top_builddir)/src/liblcms2
 liblcms2_fast_float_la_SOURCES = \
   fast_float_15bits.c fast_float_15mats.c fast_float_curves.c fast_float_matsh.c fast_float_separate.c \
   fast_float_sup.c fast_float_tethra.c fast_float_cmyk.c fast_float_internal.h \
-  fast_8_curves.c fast_8_matsh.c fast_8_matsh_sse.c fast_8_tethra.c
-
+  fast_8_curves.c fast_8_matsh.c fast_8_matsh_sse.c fast_8_tethra.c fast_16_tethra.c


### PR DESCRIPTION
I've created a pull to incorporate building and installing the fast_float plugin via the autoconf configure.  It implements a ./configure --with-fastfloat parameter, that will allow make and make install to build and install the static liblcms2_fast_float.a and lcms2_fast_float.h in /usr/local/*.  The ./configure --help documents the GPL 3.0 constraint for --with-fastfloat.

I know this is probably a bit of an overreach for an outside developer, but I'm working on incorporating the fast_float plugin in the RawTherapee build process and something like this is the best thing I can conjure to retain a hope that "regular people" will be able to compile RawTherapee with fast_float.  I've tested fast_float with my rawproc software, and it helps me retain LittleCMS for my display transform, which happens quite regularly.

The pull request is in a branch named build_fastfloat...
