### PR TITLE
configure.ac: fix static linking with tiff

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -330,7 +330,7 @@ then
 	AC_MSG_RESULT(no -- some components failed test)
 	have_tiff='no (failed tests)'
     else
-	LIB_TIFF='-ltiff'
+	PKG_CHECK_MODULES(PC_TIFF,libtiff-4,LIB_TIFF=$PC_TIFF_LIBS,LIB_TIFF='-ltiff')
 	LIBS="$LIB_TIFF $LIBS"
 	AC_DEFINE(HasTIFF,1,Define if you have TIFF library)
 	AC_MSG_RESULT(yes)


### PR DESCRIPTION
Use pkg-config to retrieve the dependencies of tiff (e.g. xz) to fix the following static build failure:

```
libtool: link: /home/buildroot/autobuild/run/instance-2/output-1/host/bin/xtensa-linux-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -mlongcalls -mauto-litpools -Os -static -fvisibility=hidden -static -static -o tificc tificc.o ../common/xgetopt.o ../common/vprf.o  ../../src/.libs/liblcms2.a -ltiff -ljpeg -lz -lm -lpthread
/home/buildroot/autobuild/run/instance-2/output-1/host/opt/ext-toolchain/bin/../lib/gcc/xtensa-buildroot-linux-uclibc/9.3.0/../../../../xtensa-buildroot-linux-uclibc/bin/ld: /home/buildroot/autobuild/run/instance-2/output-1/host/xtensa-buildroot-linux-uclibc/sysroot/usr/lib/libtiff.a(tif_lzma.o): in function `LZMAEncode':
tif_lzma.c:(.text+0x168): undefined reference to `lzma_code'
```

Fixes:
 - http://autobuild.buildroot.org/results/07c5ca780bcdbfcd7cad6502345f1553ce17bdc3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>