### PR TITLE
Ensure threadsafe alternative of gmtime is used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,9 @@ AX_APPEND_COMPILE_FLAGS(["-fvisibility=hidden"])
 # Motorola and SPARC CPUs), define `WORDS_BIGENDIAN'.
 AC_C_BIGENDIAN
 
+# Check for functions that some compilers lack (or name differently)
+AC_CHECK_FUNCS([gmtime_r _gmtime64_s])
+
 # Point to JPEG installed in DIR or disable JPEG with --without-jpeg.
 AC_ARG_WITH(jpeg,
             AS_HELP_STRING([--with-jpeg=DIR],[use jpeg installed in DIR]),


### PR DESCRIPTION
Hello, thanks for maintaining LCMS.

As discussed in https://github.com/mm2/Little-CMS/issues/170, `gmtime` uses internal storage that is static, which means that it's not threadsafe. This PR ensures that threadsafe alternatives of this function are used (if available).

This has been successfully tested on the [JPEG XL test suite](https://github.com/libjxl/libjxl/blob/main/doc/building_and_testing.md) under ThreadSanitizer without requiring a mutex in the top-level APIs (see https://github.com/libjxl/libjxl/issues/53).

Cheers,
Kleis