### PR TITLE
Prefer to use gmtime_s instead

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,8 +81,21 @@ AX_APPEND_COMPILE_FLAGS(["-fvisibility=hidden"])
 # Motorola and SPARC CPUs), define `WORDS_BIGENDIAN'.
 AC_C_BIGENDIAN
 
-# Check for functions that some compilers lack (or name differently)
-AC_CHECK_FUNCS([gmtime_r _gmtime64_s])
+# Check for threadsafe variants of gmtime
+# Note: check for gmtime_s is a bit more complex as it is implemented as a macro
+AC_CHECK_FUNCS(gmtime_r, [], [
+               AC_MSG_CHECKING([for gmtime_s])
+               AC_LINK_IFELSE([
+                 AC_LANG_PROGRAM([[#include <time.h>]], [[
+                   time_t t;
+                   struct tm m;
+                   gmtime_s(&m, &t);
+                   return 0;
+                 ]])],
+                 [AC_MSG_RESULT([yes])
+                  AC_DEFINE([HAVE_GMTIME_S], [1], [gmtime_s can be used])], 
+                 [AC_MSG_RESULT([no])]
+               )])
 
 # Point to JPEG installed in DIR or disable JPEG with --without-jpeg.
 AC_ARG_WITH(jpeg,

--- a/src/cmsplugin.c
+++ b/src/cmsplugin.c
@@ -993,7 +993,7 @@ void* CMSEXPORT cmsGetContextUserData(cmsContext ContextID)
 cmsBool _cmsGetTime(struct tm* ptr_time)
 {
     struct tm* t;
-#if defined(HAVE_GMTIME_R) || defined(HAVE__GMTIME64_S)
+#if defined(HAVE_GMTIME_R) || defined(HAVE_GMTIME_S)
     struct tm tm;
 #endif
 
@@ -1001,8 +1001,8 @@ cmsBool _cmsGetTime(struct tm* ptr_time)
 
 #ifdef HAVE_GMTIME_R
     t = gmtime_r(&now, &tm);
-#elif defined(HAVE__GMTIME64_S)
-    t = _gmtime64_s(&tm, &now) == 0 ? &tm : NULL;
+#elif defined(HAVE_GMTIME_S)
+    t = gmtime_s(&tm, &now) == 0 ? &tm : NULL;
 #else
     _cmsEnterCriticalSectionPrimitive(&_cmsContextPoolHeadMutex);
     t = gmtime(&now);


### PR DESCRIPTION
MinGW-w64 defines `_gmtime64_s` on both i686 and x86_64 targets.
Prefer to use the `gmtime_s` macro to avoid that `_gmtime64_s` is
being called on Windows 32-bit, which will not work.

This PR also generally ensures that a threadsafe alternative
is provided for toolchains targeting Windows i686.

Context: https://github.com/libvips/build-win64-mxe/issues/31.