### PR TITLE
Really fix alpha handling in fast float (hopefully...)

### DIFF
--- a/plugins/fast_float/src/fast_16_tethra.c
+++ b/plugins/fast_float/src/fast_16_tethra.c
@@ -293,6 +293,7 @@ void PerformanceEval16(struct _cmstransform_struct *CMMcargo,
                   {
                       res16 = *(const cmsUInt16Number*)ain;
                       TO_OUTPUT(out[OutChan], res16);
+                      ain += SourceIncrements[TotalOut];
                       out[TotalOut] += DestIncrements[TotalOut];
                   }
 

--- a/plugins/fast_float/src/fast_8_tethra.c
+++ b/plugins/fast_float/src/fast_8_tethra.c
@@ -253,6 +253,7 @@ void PerformanceEval8(struct _cmstransform_struct *CMMcargo,
 
                      if (ain) {
                          *out[TotalOut] = *ain;
+                         ain += SourceIncrements[TotalOut];
                          out[TotalOut] += DestIncrements[TotalOut];
                      }
 

--- a/plugins/fast_float/src/fast_float_curves.c
+++ b/plugins/fast_float/src/fast_float_curves.c
@@ -261,8 +261,8 @@ static void FastEvaluateFloatGrayCurves(struct _cmstransform_struct* CMMcargo,
 
         if (nalpha)
         {
-            ain = (const cmsUInt8Number*)Input + SourceStartingOrder[1];
-            aout = (cmsUInt8Number*)Output + DestStartingOrder[1];
+            ain = (const cmsUInt8Number*)Input + SourceStartingOrder[1] + strideIn;
+            aout = (cmsUInt8Number*)Output + DestStartingOrder[1] + strideOut;
         }
 
         for (ii = 0; ii < PixelsPerLine; ii++) {
@@ -325,8 +325,8 @@ static void FastFloatGrayIdentity(struct _cmstransform_struct* CMMcargo,
 
         if (nalpha)
         {
-            ain = (const cmsUInt8Number*)Input + SourceStartingOrder[1];
-            aout = (cmsUInt8Number*)Output + DestStartingOrder[1];
+            ain = (const cmsUInt8Number*)Input + SourceStartingOrder[1] + strideIn;
+            aout = (cmsUInt8Number*)Output + DestStartingOrder[1] + strideOut;
         }
 
 

--- a/plugins/fast_float/src/fast_float_tethra.c
+++ b/plugins/fast_float/src/fast_float_tethra.c
@@ -212,6 +212,7 @@ void FloatCLUTEval(struct _cmstransform_struct* CMMcargo,
 
             if (ain) {
                 *(cmsFloat32Number*)(out[TotalOut]) = *ain;
+                ain += SourceIncrements[TotalOut];
                 out[TotalOut] += DestIncrements[TotalOut];
             }
         }


### PR DESCRIPTION
It turned out I had missed adjusting the input pointers for the alpha channels in my first attempt to fix it, so it copied the same pixel to the whole output line.

Also, while looking at all the code again to find the issue, I noticed the stride values were missing in FastEvaluateFloatGrayCurves and FastFloatGrayIdentity.

I hope this fixes the alpha issues for real now...