### PR TITLE
cmsReadTag memory race

### DIFF
--- a/src/cmsio0.c
+++ b/src/cmsio0.c
@@ -1507,7 +1507,7 @@ cmsBool IsTypeSupported(cmsTagDescriptor* TagDescriptor, cmsTagTypeSignature Typ
 void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
 {
     _cmsICCPROFILE* Icc = (_cmsICCPROFILE*) hProfile;
-    cmsIOHANDLER* io = Icc ->IOhandler;
+    cmsIOHANDLER* io;
     cmsTagTypeHandler* TypeHandler;
     cmsTagTypeHandler LocalTypeHandler;
     cmsTagDescriptor*  TagDescriptor;
@@ -1548,6 +1548,7 @@ void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
 
     if (TagSize < 8) goto Error;
 
+    io = Icc ->IOhandler;
     // Seek to its location
     if (!io -> Seek(io, Offset))
         goto Error;


### PR DESCRIPTION
I have found this issue while working on lcms support in the OpenJDK. One of our testcase rarely crashed when the lcms is used in the very concurrent code, around thousand of threads.

I can reproduce the problem on linux and mac(I think the problem exists on windows as well but I cannot reproduce it even after a few hours of test execution) common crash stack traces are:
```
C [liblcms.so+0x4ac70] _cmsReadTypeBase+0x20
C [liblcms.so+0x253aa] cmsReadTag+0x1ba
C [liblcms.so+0x2629e] ReadICCMatrixRGB2XYZ+0x1e
C [liblcms.so+0x26acc] _cmsReadOutputLUT+0xac
C [liblcms.so+0x125ff] DefaultICCintents+0x39f
C [liblcms.so+0x5fbe3] cmsCreateExtendedTransform+0x2a3
C [liblcms.so+0x6019c] cmsCreateMultiprofileTransformTHR+0xfc
C [liblcms.so+0x6022a] cmsCreateMultiprofileTransform+0x5a 
```
or 
```
C [liblcms.dylib+0x24150] NULLSeek+0x30
C [liblcms.dylib+0x266e8] cmsReadTag+0x118
C [liblcms.dylib+0x28a2e] ReadICCMatrixRGB2XYZ+0x1e
C [liblcms.dylib+0x27e14] _cmsReadOutputLUT+0x234
C [liblcms.dylib+0xeca9] DefaultICCintents+0x2e9
C [liblcms.dylib+0x4e5fb] cmsCreateExtendedTransform+0x2db
C [liblcms.dylib+0x4f165] cmsCreateMultiprofileTransform+0x105 
```

I cannot debug the problem and properly trace its execution since every time I change something the problem disappeared, I bet that the problem is in the read of the ICC-IOhandler without synchronization via mutex in the cmsReadTag function. So I added an assert to the method and compare the IOhandler which was read before the mutex and the IOhandler after the mutext, and just before the crash that values became different. First IOhandler(which was read before the mutext) contained some garbage, or it internals contained some garbage.

So here is my suggestion to update the code in the cmsReadTag, and read the IOhandler just before the usage.