### PR TITLE
Linear RGB also comes in 32-bit and floating point

### DIFF
--- a/src/cmsxform.c
+++ b/src/cmsxform.c
@@ -1082,7 +1082,7 @@ cmsHTRANSFORM CMSEXPORT cmsCreateExtendedTransform(cmsContext ContextID,
     }
 
     // Check whatever the transform is 16 bits and involves linear RGB in first profile. If so, disable optimizations
-    if (EntryColorSpace == cmsSigRgbData && T_BYTES(InputFormat) == 2 && !(dwFlags & cmsFLAGS_NOOPTIMIZE))
+    if (EntryColorSpace == cmsSigRgbData && (T_BYTES(InputFormat) >= 2 || T_FLOAT(InputFormat)) && !(dwFlags & cmsFLAGS_NOOPTIMIZE))
     {
         cmsFloat64Number gamma = cmsDetectRGBProfileGamma(hProfiles[0], 0.1);
 


### PR DESCRIPTION
Hi @mm2,

In https://github.com/mm2/Little-CMS/commit/6b04ee0bab3ebe6f2c487195bac7b86efadd58d3 you added an automatic kill switch to disable optimization in case of a linear RGB space. In doing so, 32-bit and/or floating-point color spaces were left out, which broke Krita's out of gamut warnings as well as palette docker in the presence of OCIO.

This commit adds those two types of space to the check.

Fixes Krita bugs 442004 and 437429.

/cc @Lynx3d 
