### PR TITLE
Fix copy alpha type mismatch in FloatCLUTEval

### DIFF
--- a/plugins/fast_float/src/fast_float_tethra.c
+++ b/plugins/fast_float/src/fast_float_tethra.c
@@ -211,7 +211,7 @@ void FloatCLUTEval(struct _cmstransform_struct* CMMcargo,
             }
 
             if (ain) {
-                *(cmsFloat32Number*)(out[TotalOut]) = *ain;
+                *(cmsFloat32Number*)(out[TotalOut]) = *(cmsFloat32Number*)ain;
                 ain += SourceIncrements[TotalOut];
                 out[TotalOut] += DestIncrements[TotalOut];
             }


### PR DESCRIPTION
One more alpha channel bug that somehow slipped my testing when preparing PR #271.

A missing type cast caused a blank canvas in Krita when using float color space in combination with a CLUT display profile, so still related to issue #247.

All good things come in threes...