### PR TITLE
Fix float CMYK & Lab copy Alpha, and a previous mistake

### DIFF
--- a/plugins/fast_float/src/fast_16_tethra.c
+++ b/plugins/fast_float/src/fast_16_tethra.c
@@ -293,7 +293,7 @@ void PerformanceEval16(struct _cmstransform_struct *CMMcargo,
                   {
                       res16 = *(const cmsUInt16Number*)ain;
                       TO_OUTPUT(out[OutChan], res16);
-                      ain += SourceIncrements[TotalOut];
+                      ain += SourceIncrements[3];
                       out[TotalOut] += DestIncrements[TotalOut];
                   }
 

--- a/plugins/fast_float/src/fast_8_tethra.c
+++ b/plugins/fast_float/src/fast_8_tethra.c
@@ -253,7 +253,7 @@ void PerformanceEval8(struct _cmstransform_struct *CMMcargo,
 
                      if (ain) {
                          *out[TotalOut] = *ain;
-                         ain += SourceIncrements[TotalOut];
+                         ain += SourceIncrements[3];
                          out[TotalOut] += DestIncrements[TotalOut];
                      }
 

--- a/plugins/fast_float/src/fast_float_cmyk.c
+++ b/plugins/fast_float/src/fast_float_cmyk.c
@@ -304,8 +304,9 @@ void FloatCMYKCLUTEval(struct _cmstransform_struct *CMMcargo,
             }
 
             if (ain)
-                *out[TotalOut] = *ain;
-
+                *(cmsFloat32Number*)(out[TotalOut]) = *(cmsFloat32Number*)ain;
+                ain += SourceIncrements[4];
+                out[TotalOut] += DestIncrements[TotalOut];
         }
 
         strideIn += Stride->BytesPerLineIn;

--- a/plugins/fast_float/src/fast_float_lab.c
+++ b/plugins/fast_float/src/fast_float_lab.c
@@ -317,7 +317,8 @@ void LabCLUTEval(struct _cmstransform_struct* CMMcargo,
 
             if (xin)
             {
-                *(cmsFloat32Number*) (out[TotalOut]) = *xin;
+                *(cmsFloat32Number*) (out[TotalOut]) = *(cmsFloat32Number*)xin;
+                xin += SourceIncrements[3];
                 out[TotalOut] += DestIncrements[TotalOut];
             }
         }

--- a/plugins/fast_float/src/fast_float_tethra.c
+++ b/plugins/fast_float/src/fast_float_tethra.c
@@ -212,7 +212,7 @@ void FloatCLUTEval(struct _cmstransform_struct* CMMcargo,
 
             if (ain) {
                 *(cmsFloat32Number*)(out[TotalOut]) = *(cmsFloat32Number*)ain;
-                ain += SourceIncrements[TotalOut];
+                ain += SourceIncrements[3];
                 out[TotalOut] += DestIncrements[TotalOut];
             }
         }


### PR DESCRIPTION
Turned out I made a mistake with channel index, tethra is always 3 + Alpha as input, so when converting RGB => CMYK it would crash because I used the output Alpha index.

And the Krita unit tests still weren't happy with image bounds on float => float conversions involving Lab or CMYK, so I dug around some more, and found the missing places.

I hope this is now really the last patch required :)