### PR TITLE
Xcode 13.3 warning on var set but not used in cmstypes.c

### DIFF
--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -3471,7 +3471,6 @@ void *Type_ProfileSequenceId_Read(struct _cms_typehandler_struct* self, cmsIOHAN
 
     // Get table count
     if (!_cmsReadUInt32Number(io, &Count)) return NULL;
-    SizeOfTag -= sizeof(cmsUInt32Number);
 
     // Allocate an empty structure
     OutSeq = cmsAllocProfileSequenceDescription(self ->ContextID, Count);
@@ -3489,6 +3488,7 @@ void *Type_ProfileSequenceId_Read(struct _cms_typehandler_struct* self, cmsIOHAN
     *nItems = 1;
     return OutSeq;
 
+    cmsUNUSED_PARAMETER(SizeOfTag);
 }
 
 


### PR DESCRIPTION
We had an OpenJDK bug report from some one experimenting with the very latest Xcode 13.3 : https://bugs.openjdk.java.net/browse/JDK-8283221

The gist of it is that OpenJDK defaults to warnings as errors and the latest clang reports


cmstypes.c: parameter 'SizeOfTag' set but not used [-Werror,-Wunused-but-set-parameter]
void *Type_ProfileSequenceId_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsUInt32Number* nItems, cmsUInt32Number SizeOfTag)

It corresponds to the case fixed in this PR.

I guess there may once have been a subsequent read that needed this check, or perhaps it is just a pattern to make sure a check is always present in case another read is added.
