### PR TITLE
Fix out-of-tree build. Requires rerunning autoconf.

### DIFF
--- a/plugins/fast_float/testbed/Makefile.am
+++ b/plugins/fast_float/testbed/Makefile.am
@@ -6,17 +6,16 @@
 AUTOMAKE_OPTIONS = 1.7 foreign
 
 AM_CPPFLAGS	=  -I$(builddir)/../include -I$(srcdir)/../include -I$(srcdir)/../src \
-                   -I$(top_builddir)/include 
+                   -I$(top_builddir)/include
 
 check_PROGRAMS = fast_float_testbed
 
-fast_float_testbed_LDADD =  $(srcdir)/../src/liblcms2_fast_float.la $(LCMS_LIB_DEPLIBS)
+fast_float_testbed_LDADD =  $(builddir)/../src/liblcms2_fast_float.la $(LCMS_LIB_DEPLIBS)
 fast_float_testbed_LDFLAGS = -static @LDFLAGS@
-fast_float_testbed_SOURCES = fast_float_testbed.c 
+fast_float_testbed_SOURCES = fast_float_testbed.c
 
-EXTRA_DIST = test0.icc test1.icc test2.icc test3.icc test5.icc 
+EXTRA_DIST = test0.icc test1.icc test2.icc test3.icc test5.icc
 
 check:
+	cp $(srcdir)/test?.icc .
 	./fast_float_testbed
-
-


### PR DESCRIPTION
When building lcms2 out-of-tree with --with-fast-float, "make check" fails because

1. The build files try to link the testbed to the plugin on a path relative to the source directory instead of the build directory;
2. The testbed expects the test?.icc files to be in the same directory.

Fix this by changing it to link relative to the build directory and by copying the test?.icc files to the build directory.

Autoreconf needs to be rerun after this to generate the build files. I thought it better to not send a messy pull request with thousands of lines of generated content.

I'm sorry for the couple of extra whitespace changes in this small file; it seems I need to look at my editor config...