### PR TITLE
Update meson to build utils

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build Ubuntu
         run: |
-          meson setup build
+          meson setup build -Dutils=true
           meson compile -C build
           meson test -C build
 

--- a/meson.build
+++ b/meson.build
@@ -84,3 +84,7 @@ liblcms2_dep = declare_dependency(
 
 pkg = import('pkgconfig')
 pkg.generate(liblcms2_lib)
+
+if get_option('utils')
+  subdir('utils')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,6 @@ option(
 
 option(
   'jpeg',
-  type : 'boolean',
-  value : true,
+  type : 'feature',
+  value : 'enabled',
   description : 'Enable building with jpeg')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,11 @@
+option(
+  'utils',
+  type : 'boolean',
+  value : false,
+  description : 'Enable building utils')
+
+option(
+  'jpeg',
+  type : 'boolean',
+  value : true,
+  description : 'Enable building with jpeg')

--- a/utils/jpgicc/meson.build
+++ b/utils/jpgicc/meson.build
@@ -1,0 +1,24 @@
+#project('jpegicc', 'c')
+
+jpegicc_srcs = [
+  'jpgicc.c',
+  'iccjpeg.c',
+  '../common/xgetopt.c',
+  '../common/vprf.c',
+  '../common/utils.h',
+]
+
+inc_common_dirs = include_directories('../common')
+
+libjpeg_dep = dependency('libjpeg', required: get_option('jpeg'))
+if libjpeg_dep.found()
+  executable('jpegicc',
+    jpegicc_srcs,
+    c_args: cargs,
+    dependencies : [liblcms2_dep, libjpeg_dep],
+    include_directories : inc_common_dirs,
+    install : true)
+endif
+
+#man_MANS = jpgicc.1
+#EXTRA_DIST = iccjpeg.h $(man_MANS)

--- a/utils/jpgicc/meson.build
+++ b/utils/jpgicc/meson.build
@@ -20,5 +20,5 @@ if libjpeg_dep.found()
     install : true)
 endif
 
-#man_MANS = jpgicc.1
+install_man('jpgicc.1')
 #EXTRA_DIST = iccjpeg.h $(man_MANS)

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -1,0 +1,5 @@
+subdir('jpgicc')
+#subdir('linkicc')
+#subdir('psicc')
+#subdir('tificc')
+#subdir('transicc')


### PR DESCRIPTION
### Draft
- fixes #335 


Building with `-Dutils=true` will now build the ICC utils (same as `configure; make`)

e.g.
```
Installing utils/jpgicc/jpegicc to …/install_pkg/lcms2-2.13.1/usr/bin
Stripping target 'utils/jpgicc/jpegicc'.
```

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>