### PR TITLE
configure.ac: fix configure tests broken with Clang 15 (-Wimplicit-int)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,7 @@ AC_LANG_PUSH([C])
 AC_MSG_CHECKING([whether compiler supports SSE2])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
     #include <emmintrin.h>
-    main() { __m128i n = _mm_set1_epi8(42); }]])],
+    int main() { __m128i n = _mm_set1_epi8(42); }]])],
   [ac_compiler_supports_sse2=yes], [ac_compiler_supports_sse2=no])
 AC_MSG_RESULT([$ac_compiler_supports_sse2])
 AS_IF([test "x$ac_compiler_supports_sse2" != "xyes"],


### PR DESCRIPTION
Clang 15 makes -Wimplicit-int an error by default.

Before this fix, configure would think SSE2 support is not present when it is:
```
checking whether compiler supports SSE2... no
```

Signed-off-by: Sam James <sam@gentoo.org>