### PR TITLE
Ensure plugins can be built and installed with Meson

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build Ubuntu
         run: |
-          meson setup build
+          meson setup build -Dfastfloat=true
           meson compile -C build
           meson test -C build
 

--- a/plugins/fast_float/include/meson.build
+++ b/plugins/fast_float/include/meson.build
@@ -1,0 +1,1 @@
+install_headers('lcms2_fast_float.h')

--- a/plugins/fast_float/meson.build
+++ b/plugins/fast_float/meson.build
@@ -1,2 +1,3 @@
+subdir('include')
 subdir('src')
 subdir('testbed')

--- a/plugins/fast_float/src/meson.build
+++ b/plugins/fast_float/src/meson.build
@@ -32,7 +32,7 @@ liblcms2_fast_float = library(
   'lcms2_fast_float',
   lcms2_fast_float_sources,
   gnu_symbol_visibility: 'hidden',
-  dependencies: liblcms2_dep,
+  dependencies: [liblcms2_dep, m_dep],
   include_directories: lcms2_fast_float_incdir,
   c_args: cargs,
   install: true,

--- a/plugins/fast_float/testbed/meson.build
+++ b/plugins/fast_float/testbed/meson.build
@@ -5,7 +5,7 @@ fast_float_testbed_srcs = files(
 fast_float_testbed = executable(
   'fast_float_testbed',
   fast_float_testbed_srcs,
-  dependencies: [liblcms2_fast_float_dep, liblcms2_dep],
+  dependencies: [liblcms2_fast_float_dep, liblcms2_dep, m_dep],
   c_args: cargs + ['-DPROFILES_DIR="@0@"'.format(profiles_dir / '')],
 )
 

--- a/plugins/threaded/include/meson.build
+++ b/plugins/threaded/include/meson.build
@@ -1,1 +1,1 @@
-
+install_headers('lcms2_threaded.h')

--- a/plugins/threaded/meson.build
+++ b/plugins/threaded/meson.build
@@ -1,2 +1,3 @@
+subdir('include')
 subdir('src')
 subdir('testbed')


### PR DESCRIPTION
Hola Marti, this small PR makes the dependency on the `m` library explicit when building via Meson to avoid undefined reference errors during compilation/linking.

It also allows the development headers to be installed, matching the behaviour of the autotools-based build.

Finally it enables the "fastfloat" option in the Meson-based CI job so it matches the behaviour of the existing autotools-based CI job. (I'm unsure if there's a desire to also enable the "threaded" option, but this PR at least makes things consistent.)
