### PR TITLE
Meson: skip utils with missing optional dependencies

### DIFF
--- a/utils/meson.build
+++ b/utils/meson.build
@@ -1,6 +1,10 @@
 subdir('common')
-subdir('jpgicc')
+if jpeg_dep.found()
+  subdir('jpgicc')
+endif
 subdir('linkicc')
 subdir('psicc')
-subdir('tificc')
+if tiff_dep.found()
+  subdir('tificc')
+endif
 subdir('transicc')


### PR DESCRIPTION
- `jpgicc` depends on optional `libjpeg`
- `tificc` depends on optional `libtiff-4`
