### PR TITLE
meson: fix big endian cargs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ if cc.has_function_attribute('visibility:hidden')
 endif
 
 if host_machine.endian() == 'big'
-  cargs = '-DWORDS_BIGENDIAN=1'
+  cargs += '-DWORDS_BIGENDIAN=1'
 endif
 
 


### PR DESCRIPTION
otherwise they are a string and appending with + [""] later fails in
plugins/fast_float/testbed/meson.build:5:0: ERROR: The `+` operator of str does not accept objects of type list (['-DPROFILES_DIR="/home/buildozer/aports/main/lcms2/src/lcms2-2.15/plugins/test_profiles/"'])