### PR TITLE
Fix building on case sensitive mingw platforms

### DIFF
--- a/plugins/fast_float/src/lcms2_fast_float.rc.in
+++ b/plugins/fast_float/src/lcms2_fast_float.rc.in
@@ -19,7 +19,7 @@
 //
 //---------------------------------------------------------------------------------
 
-#include <Windows.h>
+#include <windows.h>
 
 1 VERSIONINFO
 FILEVERSION @LCMS2_VERSION_MAJOR@, @LCMS2_VERSION_MINOR@, @LCMS2_VERSION_MICRO@, 0

--- a/plugins/threaded/src/lcms2_threaded.rc.in
+++ b/plugins/threaded/src/lcms2_threaded.rc.in
@@ -19,7 +19,7 @@
 //
 //---------------------------------------------------------------------------------
 
-#include <Windows.h>
+#include <windows.h>
 
 1 VERSIONINFO
 FILEVERSION @LCMS2_VERSION_MAJOR@, @LCMS2_VERSION_MINOR@, @LCMS2_VERSION_MICRO@, 0

--- a/src/lcms2.rc.in
+++ b/src/lcms2.rc.in
@@ -19,7 +19,7 @@
 //
 //---------------------------------------------------------------------------------
 
-#include <Windows.h>
+#include <windows.h>
 
 1 VERSIONINFO
 FILEVERSION @LCMS2_VERSION_MAJOR@, @LCMS2_VERSION_MINOR@, @LCMS2_VERSION_MICRO@, 0


### PR DESCRIPTION
Mingw headers are all lowercase, and can be used for cross compilation from case sensitive file systems.

The official Windows SDK headers aren't self-consistent wrt upper/lower case, so those headers can't be used on case sensitive systems without a layer providing case insensitivity anyway.

This matches other includes of windows.h throughout the codebase.