### PR TITLE
Fix MSYS2 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   Ubuntu:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,3 +101,56 @@ jobs:
           meson setup build
           meson compile -C build
           meson test -C build
+
+  msys-meson:
+    name: 'msys-meson ${{ matrix.sys.abi }} ${{ matrix.library }}'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        sys:
+          - { abi: mingw64, env: x86_64,       compiler: gcc }
+          - { abi: ucrt64,  env: ucrt-x86_64,  compiler: gcc }
+          - { abi: clang64, env: clang-x86_64, compiler: clang }
+        library: ['shared', 'static']
+      fail-fast: false
+    steps:
+      - name: Use MinGW from MSYS
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys.abi}}
+          update: true
+          path-type: inherit
+          install: >-
+            mingw-w64-${{matrix.sys.env}}-toolchain
+
+      - name: Setup compiler
+        if: startsWith(matrix.sys.abi, 'mingw64') || startsWith(matrix.sys.abi, 'ucrt64')
+        run: |
+          CXX=${CC/#gcc/g++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.sys.compiler }}
+      - name: Setup compiler
+        if: startsWith(matrix.sys.abi, 'clang64')
+        run: |
+          CXX=${CC/#clang/clang++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.sys.compiler }}
+
+      - uses: actions/checkout@v2
+
+      - name: Install packages
+        run: |
+          pip install meson==1.0.0
+
+      - name: Build Windows
+        run: |
+          meson setup build -Dfastfloat=true -Dthreaded=true -Dsamples=true -Ddefault_library=${{ matrix.library }}
+          meson compile -C build
+          meson test -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,8 +111,10 @@ jobs:
     strategy:
       matrix:
         sys:
+          - { abi: mingw32, env: i686,         compiler: gcc }
           - { abi: mingw64, env: x86_64,       compiler: gcc }
           - { abi: ucrt64,  env: ucrt-x86_64,  compiler: gcc }
+          - { abi: clang32, env: clang-i686,   compiler: clang }
           - { abi: clang64, env: clang-x86_64, compiler: clang }
         library: ['shared', 'static']
       fail-fast: false
@@ -127,7 +129,7 @@ jobs:
             mingw-w64-${{matrix.sys.env}}-toolchain
 
       - name: Setup compiler
-        if: startsWith(matrix.sys.abi, 'mingw64') || startsWith(matrix.sys.abi, 'ucrt64')
+        if: startsWith(matrix.sys.abi, 'mingw') || startsWith(matrix.sys.abi, 'ucrt64')
         run: |
           CXX=${CC/#gcc/g++}
           echo "CC=$CC" >> $GITHUB_ENV
@@ -135,7 +137,7 @@ jobs:
         env:
           CC: ${{ matrix.sys.compiler }}
       - name: Setup compiler
-        if: startsWith(matrix.sys.abi, 'clang64')
+        if: startsWith(matrix.sys.abi, 'clang')
         run: |
           CXX=${CC/#clang/clang++}
           echo "CC=$CC" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,9 +124,11 @@ jobs:
         with:
           msystem: ${{matrix.sys.abi}}
           update: true
-          path-type: inherit
+          path-type: minimal
           install: >-
             mingw-w64-${{matrix.sys.env}}-toolchain
+            mingw-w64-${{matrix.sys.env}}-meson
+            mingw-w64-${{matrix.sys.env}}-ninja
 
       - name: Setup compiler
         if: startsWith(matrix.sys.abi, 'mingw') || startsWith(matrix.sys.abi, 'ucrt64')
@@ -146,10 +148,6 @@ jobs:
           CC: ${{ matrix.sys.compiler }}
 
       - uses: actions/checkout@v2
-
-      - name: Install packages
-        run: |
-          pip install meson==1.0.0
 
       - name: Build Windows
         run: |

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project(
   'c',
   version: '2.15',
   meson_version: '>=0.49.0',
+  default_options: ['c_std=gnu11']
 )
 
 version_components = meson.project_version().split('.')
@@ -33,7 +34,7 @@ endif
 
 # Check for threadsafe variants of gmtime
 # MinGW needs _POSIX_C_SOURCE or _POSIX_THREAD_SAFE_FUNCTIONS defined
-# to make gmtime_r available
+# to make gmtime_r and pthread_time.h available
 if host_machine.system() == 'windows' and cc.get_argument_syntax() != 'msvc'
   cargs += ['-D_POSIX_C_SOURCE=199503L']
 endif
@@ -86,6 +87,10 @@ if cc.has_function('pthread_mutex_lock', dependencies: threads_dep)
   cargs += '-DHasTHREADS=1'
 else
   cargs += '-DHasTHREADS=0'
+endif
+
+if cc.has_header_symbol('time.h', 'timespec_get')
+  cargs += '-DHAVE_TIMESPEC_GET=1'
 endif
 
 win = import('windows')

--- a/plugins/threaded/testbed/threaded_testbed.c
+++ b/plugins/threaded/testbed/threaded_testbed.c
@@ -50,7 +50,7 @@ static struct timespec start, finish;
 
 cmsINLINE void MeasureTimeStart(void)
 {    
-#ifdef CMS_IS_WINDOWS_
+#if defined(HAVE_TIMESPEC_GET)
     timespec_get(&start, TIME_UTC);
 #else
     clock_gettime(CLOCK_MONOTONIC, &start);
@@ -61,7 +61,7 @@ cmsINLINE double MeasureTimeStop(void)
 {
     double elapsed;
 
-#ifdef CMS_IS_WINDOWS_
+#if defined(HAVE_TIMESPEC_GET)
     timespec_get(&finish, TIME_UTC);
 #else
     clock_gettime(CLOCK_MONOTONIC, &finish);

--- a/src/lcms2.def
+++ b/src/lcms2.def
@@ -364,4 +364,9 @@ cmsMD5finish                             =   cmsMD5finish
 _cmsComputeInterpParams                  =   _cmsComputeInterpParams
 cmsGetToneCurveParams                    =   cmsGetToneCurveParams
 cmsDetectRGBProfileGamma                 =   cmsDetectRGBProfileGamma
-
+_cmsOptimizePipeline                     =   _cmsOptimizePipeline
+_cmsReasonableGridpointsByColorspace     =   _cmsReasonableGridpointsByColorspace
+_cmsGetTransformFlags                    =   _cmsGetTransformFlags
+_cmsGetTransformWorker                   =   _cmsGetTransformWorker
+_cmsGetTransformMaxWorkers               =   _cmsGetTransformMaxWorkers
+_cmsGetTransformWorkerFlags              =   _cmsGetTransformWorkerFlags


### PR DESCRIPTION
Hey @mm2,

This PR groups together the fixes needed to enable CI for all Intel MSYS2 flavors:

- used concurrency groups to supersede builds quickly when force-pushing
- fixed the missing exported APIs issue I reported in the mialing list
- fixed your usage of `timespec_get` in the threaded plugin test bench, which on Windows, is UCRT-only and C11 or higher

As regards the missing private APIs-- given that you intend to use GCC's visibility to export the functions in Windows, do you want me to remove the `vs_module_defs` in that case?