### PR TITLE
CI: set minimal permissions to GitHub Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
 
   Ubuntu:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,10 +14,16 @@ on:
   schedule:
     - cron: '0 6 * * 5'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Set top-level read-only permissions to all workflows; for the jobs that require write-permissions, give them only job-level

Closes #366