### PR TITLE
Allow optional build of utils using meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,7 +100,10 @@ deps = [m_dep, threads_dep]
 subdir('include')
 subdir('src')
 subdir('testbed')
-subdir('utils')
+
+if get_option('utils')
+  subdir('utils')
+endif
 
 if get_option('samples')
   subdir('utils/samples')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,5 +2,6 @@ option('jpeg', type: 'feature', value: 'auto', description: 'Use JPEG')
 option('tiff', type: 'feature', value: 'auto', description: 'Use LibTiff')
 
 option('samples', type: 'boolean', value: 'false', description: 'Build the samples')
+option('utils', type: 'boolean', value: 'true', description: 'Build the utils')
 option('fastfloat', type: 'boolean', value: 'false', description: 'Build and install the fast float plugin, use only if GPL 3.0 is acceptable')
 option('threaded', type: 'boolean', value: 'false', description: 'Build and install the multi threaded plugin, use only if GPL 3.0 is acceptable')


### PR DESCRIPTION
Add the option to meson to disable the build of utils (when only the library is required to be built.)