### PR TITLE
Fixed potentials overflows.

### DIFF
--- a/src/cmslut.c
+++ b/src/cmslut.c
@@ -574,7 +574,7 @@ cmsStage* CMSEXPORT cmsStageAllocCLut16bitGranular(cmsContext ContextID,
     NewElem -> nEntries = n = outputChan * CubeSize(clutPoints, inputChan);
     NewElem -> HasFloatValues = FALSE;
 
-    if (n == 0) {
+    if (n == 0 || n / outputChan != CubeSize(clutPoints, inputChan)) {
         cmsStageFree(NewMPE);
         return NULL;
     }
@@ -666,7 +666,7 @@ cmsStage* CMSEXPORT cmsStageAllocCLutFloatGranular(cmsContext ContextID, const c
     NewElem -> nEntries = n = outputChan * CubeSize(clutPoints, inputChan);
     NewElem -> HasFloatValues = TRUE;
 
-    if (n == 0) {
+    if (n == 0 || n / outputChan != CubeSize(clutPoints, inputChan)) {
         cmsStageFree(NewMPE);
         return NULL;
     }


### PR DESCRIPTION
Hi! I've been searching for errors in Little-CMS with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and found overflow errors in `cmslut.c:574` and `cmslut.c:669`. I've added some checks to handle them.