### PR TITLE
Fix PostScript output for linear tone curve

### DIFF
--- a/src/cmsps2.c
+++ b/src/cmsps2.c
@@ -461,8 +461,11 @@ void Emit1Gamma(cmsIOHANDLER* m, cmsToneCurve* Table, const char* name)
 
     if (Table ->nEntries <= 0) return;  // Empty table
 
-    // Suppress whole if identity
-    if (cmsIsToneCurveLinear(Table)) return;
+    // Check for identity function
+    if (cmsIsToneCurveLinear(Table)) {
+        _cmsIOPrintf(m, "/%s {} def\n", name);
+        return;
+    }
 
     // Check if is really an exponential. If so, emit "exp"
     gamma = cmsEstimateGamma(Table, 0.001);


### PR DESCRIPTION
For profiles with a linear tone curve, the Emit1Gamma function doesn't produce any output, so the PostScript code generated by LCMS may reference names (such as "lcms2gammaproc") that it does not actually define.

This patch makes it generate an empty procedure in such cases instead.