### PR TITLE
Add Scorecard GitHub Action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,55 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '38 3 * * 5'
+  push:
+    branches: [ "master" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish results to OpenSSF REST API for easy access by consumers and allows the repository to include the Scorecard badge.
+          # See https://github.com/ossf/scorecard-action#publishing-results
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Closes #393 

This PR installs the Scorecard tool, as discussed in the issue.

Additionally, I'd like to ask if you have interest on adding the Scorecard badge on your README. The badge would be auto-updated for every change made to the repository and shows off your hard work on security posture =) -- see more info [here](https://openssf.org/blog/2022/09/08/show-off-your-security-score-announcing-scorecards-badges/). 

I see that your current readme is very clean, so I'd understand if you'd rather not add it the readme; in any case, it would look like this:

[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/mm2/Little-CMS/badge)](https://securityscorecards.dev/viewer/?uri=github.com/mm2/Little-CMS)

(Although it might not seem like it, a 7/10 score is a great score! It puts Little-CMS at the top 11% of relevant projects 😄)
