### PR TITLE
whitespace + linguistic/typo fixes in the comments

### DIFF
--- a/include/lcms2_plugin.h
+++ b/include/lcms2_plugin.h
@@ -603,9 +603,9 @@ typedef void     (* _cmsTransformFn)(struct _cmstransform_struct *CMMcargo,   //
 typedef void     (*_cmsTransform2Fn)(struct _cmstransform_struct *CMMcargo,
                                      const void* InputBuffer,
                                      void* OutputBuffer,
-                                     cmsUInt32Number PixelsPerLine,     
-                                     cmsUInt32Number LineCount,          
-                                     const cmsStride* Stride);  
+                                     cmsUInt32Number PixelsPerLine,
+                                     cmsUInt32Number LineCount,
+                                     const cmsStride* Stride);
 
 typedef cmsBool  (* _cmsTransformFactory)(_cmsTransformFn* xform,
                                          void** UserData,
@@ -648,7 +648,7 @@ typedef struct {
 }  cmsPluginTransform;
 
 //----------------------------------------------------------------------------------------------------------
-// Mutex 
+// Mutex
 
 typedef void*    (* _cmsCreateMutexFnPtrType)(cmsContext ContextID);
 typedef void     (* _cmsDestroyMutexFnPtrType)(cmsContext ContextID, void* mtx);

--- a/plugins/fast_float/src/fast_8_matsh.c
+++ b/plugins/fast_float/src/fast_8_matsh.c
@@ -160,8 +160,8 @@ XMatShaper8Data* SetMatShaper(cmsContext ContextID, cmsToneCurve* Curve1[3], cms
     return p;
 }
 
-// A fast matrix-shaper evaluator for 8 bits. This is a bit ticky since I'm using 1.14 signed fixed point 
-// to accomplish some performance. Actually it takes 256x3 16 bits tables and 16385 x 3 tables of 8 bits, 
+// A fast matrix-shaper evaluator for 8 bits. This is a bit tricky since I'm using 1.14 signed fixed point
+// to accomplish some performance. Actually it takes 256x3 16 bits tables and 16385 x 3 tables of 8 bits,
 // in total about 50K, and the performance boost is huge!
 
 static
@@ -313,9 +313,9 @@ cmsBool Optimize8MatrixShaper(_cmsTransform2Fn* TransformFn,
     if (cmsStageInputChannels(Matrix1) == 1 && cmsStageOutputChannels(Matrix2) == 1)
     {
         // This is a gray to gray. Just multiply    
-         factor = Data1->Double[0]*Data2->Double[0] + 
-                  Data1->Double[1]*Data2->Double[1] + 
-                  Data1->Double[2]*Data2->Double[2];
+        factor = Data1->Double[0]*Data2->Double[0] + 
+                 Data1->Double[1]*Data2->Double[1] + 
+                 Data1->Double[2]*Data2->Double[2];
 
         if (fabs(1 - factor) < (1.0 / 65535.0)) IdentityMat = TRUE;
     }
@@ -333,11 +333,11 @@ cmsBool Optimize8MatrixShaper(_cmsTransform2Fn* TransformFn,
         }
     }
 
-      // Allocate an empty LUT 
-    Dest =  cmsPipelineAlloc(ContextID, nChans, nChans);
+    // Allocate an empty LUT 
+    Dest = cmsPipelineAlloc(ContextID, nChans, nChans);
     if (!Dest) return FALSE;
 
-    // Assamble the new LUT
+    // Assemble the new LUT
     cmsPipelineInsertStage(Dest, cmsAT_BEGIN, cmsStageDup(Curve1));
     
     if (!IdentityMat) {
@@ -363,11 +363,11 @@ cmsBool Optimize8MatrixShaper(_cmsTransform2Fn* TransformFn,
         _cmsStageToneCurvesData* mpeC2 = (_cmsStageToneCurvesData*) cmsStageData(Curve2);
                 
         // In this particular optimization, cache does not help as it takes more time to deal with 
-        // the cache that with the pixel handling
+        // the cache than with the pixel handling
         *dwFlags |= cmsFLAGS_NOCACHE;
   
 
-        // Setup the optimizarion routines
+        // Setup the optimization routines
         *UserData = SetMatShaper(ContextID, mpeC1 ->TheCurves, &res, (cmsVEC3*) Data2 ->Offset, mpeC2->TheCurves);
         *FreeUserData = FreeMatShaper; 
 

--- a/plugins/fast_float/src/fast_8_matsh_sse.c
+++ b/plugins/fast_float/src/fast_8_matsh_sse.c
@@ -404,7 +404,7 @@ cmsBool Optimize8MatrixShaperSSE(_cmsTransform2Fn* TransformFn,
         _cmsStageToneCurvesData* mpeC2 = (_cmsStageToneCurvesData*) cmsStageData(Curve2);
                 
         // In this particular optimization, cache does not help as it takes more time to deal with 
-        // the cache that with the pixel handling
+        // the cache than with the pixel handling
         *dwFlags |= cmsFLAGS_NOCACHE;
   
 

--- a/plugins/fast_float/src/fast_float_15mats.c
+++ b/plugins/fast_float/src/fast_float_15mats.c
@@ -337,7 +337,7 @@ cmsBool OptimizeMatrixShaper15(_cmsTransform2Fn* TransformFn,
               _cmsStageToneCurvesData* mpeC2 = (_cmsStageToneCurvesData*)cmsStageData(Curve2);
 
               // In this particular optimization, cache does not help as it takes more time to deal with 
-              // the cache that with the pixel handling
+              // the cache than with the pixel handling
               *dwFlags |= cmsFLAGS_NOCACHE;
 
               // Setup the optimizarion routines

--- a/plugins/fast_float/src/fast_float_15mats.c
+++ b/plugins/fast_float/src/fast_float_15mats.c
@@ -19,11 +19,11 @@
 //
 //---------------------------------------------------------------------------------
 
-// Optimization for matrix-shaper in 15 bits. Numbers are operated in 1.15 usigned, 
+// Optimization for matrix-shaper in 15 bits. Numbers are operated in 1.15 unsigned,
 
 #include "fast_float_internal.h"
 
-// An storage capable to keep 1.15 signed and some extra precission. 
+// An storage capable to keep 1.15 signed and some extra precision.
 // Actually I use 32 bits integer (signed)
 typedef cmsInt32Number cmsS1Fixed15Number;   
 

--- a/plugins/fast_float/src/fast_float_15mats.c
+++ b/plugins/fast_float/src/fast_float_15mats.c
@@ -336,7 +336,7 @@ cmsBool OptimizeMatrixShaper15(_cmsTransform2Fn* TransformFn,
               _cmsStageToneCurvesData* mpeC1 = (_cmsStageToneCurvesData*)cmsStageData(Curve1);
               _cmsStageToneCurvesData* mpeC2 = (_cmsStageToneCurvesData*)cmsStageData(Curve2);
 
-              // In this particular optimization, cache does not help as it takes more time to deal with 
+              // In this particular optimization, cache does not help as it takes more time to deal with
               // the cache than with the pixel handling
               *dwFlags |= cmsFLAGS_NOCACHE;
 

--- a/plugins/fast_float/src/fast_float_matsh.c
+++ b/plugins/fast_float/src/fast_float_matsh.c
@@ -303,11 +303,11 @@ cmsBool OptimizeFloatMatrixShaper(_cmsTransform2Fn* TransformFn,
         }
     }
 
-      // Allocate an empty LUT 
+    // Allocate an empty LUT 
     Dest =  cmsPipelineAlloc(ContextID, nChans, nChans);
     if (!Dest) return FALSE;
 
-    // Assamble the new LUT
+    // Assemble the new LUT
     cmsPipelineInsertStage(Dest, cmsAT_BEGIN, cmsStageDup(Curve1));
     
     if (!IdentityMat) {
@@ -331,12 +331,12 @@ cmsBool OptimizeFloatMatrixShaper(_cmsTransform2Fn* TransformFn,
     else {
         _cmsStageToneCurvesData* mpeC1 = (_cmsStageToneCurvesData*) cmsStageData(Curve1);
         _cmsStageToneCurvesData* mpeC2 = (_cmsStageToneCurvesData*) cmsStageData(Curve2);
-                
-        // In this particular optimization, cache does not help as it takes more time to deal with 
-        // the cachthat with the pixel handling
+
+        // In this particular optimization, cache does not help as it takes more time to deal with
+        // the cache than with the pixel handling
         *dwFlags |= cmsFLAGS_NOCACHE;
 
-        // Setup the optimizarion routines
+        // Setup the optimization routines
         *UserData = SetMatShaper(ContextID, mpeC1 ->TheCurves, &res, (cmsVEC3*) Data2 ->Offset, mpeC2->TheCurves);
         *FreeUserData = FreeMatShaper; 
 

--- a/plugins/fast_float/testbed/fast_float_testbed.c
+++ b/plugins/fast_float/testbed/fast_float_testbed.c
@@ -376,7 +376,7 @@ void Check15bitMacros(void)
        trace("ok\n");
 }
 
-// Do an in-depth test by checking all RGB cube of 8 bits, going from profilein to profileout. 
+// Do an in-depth test by checking all RGB cube of 8 bits, going from profileIn to profileOut.
 // Results should be same except for 2 contone levels allowed for roundoff. Note 15 bits is more 
 // precise than 8 bits and this is a source of discrepancies. Cache is disabled
 static 
@@ -790,7 +790,7 @@ cmsBool ValidFloat(cmsFloat32Number a, cmsFloat32Number b)
        return fabsf(a-b) < EPSILON_FLOAT_TESTS;
 }
 
-// Do an in-depth test by checking all RGB cube of 8 bits, going from profilein to profileout. 
+// Do an in-depth test by checking all RGB cube of 8 bits, going from profileIn to profileOut.
 // Values with and without optimization are checked (different contexts, one with the plugin and another without)
 // Results should be same except for EPSILON_FLOAT_TESTS allowed for accuracy/speed tradeoff. Cache is disabled
 static

--- a/src/cmsalpha.c
+++ b/src/cmsalpha.c
@@ -567,7 +567,7 @@ void _cmsHandleExtraChannels(_cmsTRANSFORM* p, const void* in,
     if (nExtra == 0)
         return;
 
-     // Compute the increments
+    // Compute the increments
     if (!ComputeComponentIncrements(p->InputFormat, Stride->BytesPerPlaneIn, SourceStartingOrder, SourceIncrements))
         return;
     if (!ComputeComponentIncrements(p->OutputFormat, Stride->BytesPerPlaneOut, DestStartingOrder, DestIncrements))

--- a/src/cmscgats.c
+++ b/src/cmscgats.c
@@ -426,7 +426,7 @@ void StringCat(string* s, const char* c)
 static
 cmsBool isseparator(int c)
 {
-    return (c == ' ') || (c == '\t') ; 
+    return (c == ' ') || (c == '\t');
 }
 
 // Checks whatever c is a valid identifier char
@@ -943,7 +943,7 @@ void InSymbol(cmsIT8* it8)
         // Next line
         case '\r':
             NextCh(it8);
-            if (it8 ->ch == '\n') 
+            if (it8->ch == '\n')
                 NextCh(it8);
             it8->sy = SEOLN;
             it8->lineno++;

--- a/src/cmscgats.c
+++ b/src/cmscgats.c
@@ -747,7 +747,7 @@ cmsFloat64Number ParseFloatNumber(const char *Buffer)
 }
 
 
-// Reads a string, special case to avoid infinite resursion on .include
+// Reads a string, special case to avoid infinite recursion on .include
 static
 void InStringSymbol(cmsIT8* it8)
 {

--- a/src/cmserr.c
+++ b/src/cmserr.c
@@ -72,7 +72,7 @@ long int CMSEXPORT cmsfilelength(FILE* f)
 //
 // This is the interface to low-level memory management routines. By default a simple
 // wrapping to malloc/free/realloc is provided, although there is a limit on the max
-// amount of memoy that can be reclaimed. This is mostly as a safety feature to prevent 
+// amount of memory that can be reclaimed. This is mostly as a safety feature to prevent
 // bogus or evil code to allocate huge blocks that otherwise lcms would never need.
 
 #define MAX_MEMORY_FOR_ALLOC  ((cmsUInt32Number)(1024U*1024U*512U))
@@ -234,7 +234,7 @@ cmsBool  _cmsRegisterMemHandlerPlugin(cmsContext ContextID, cmsPluginBase *Data)
 
     // NULL forces to reset to defaults. In this special case, the defaults are stored in the context structure. 
     // Remaining plug-ins does NOT have any copy in the context structure, but this is somehow special as the
-    // context internal data should be malloce'd by using those functions. 
+    // context internal data should be malloc'ed by using those functions.
     if (Data == NULL) {
 
        struct _cmsContext_struct* ctx = ( struct _cmsContext_struct*) ContextID;

--- a/src/cmsgmt.c
+++ b/src/cmsgmt.c
@@ -592,11 +592,11 @@ cmsBool CMSEXPORT cmsDesaturateLab(cmsCIELab* Lab,
     return TRUE;
 }
 
-// Detect whatever a given ICC profile works in linear (gamma 1.0) space
+// Detect whatever gamma a given ICC profile works with in linear (gamma 1.0) space
 // Actually, doing that "well" is quite hard, since every component may behave completely different.
 // Since the true point of this function is to detect suitable optimizations, I am imposing some requirements 
-// that simplifies things: only RGB, and only profiles that can got in both directions.
-// The algorithm obtains Y from a syntetical gray R=G=B. Then least squares fitting is used to estimate gamma. 
+// that simplify things: only RGB, and only profiles that can got in both directions.
+// The algorithm obtains Y from a synthetical gray R=G=B. Then least squares fitting is used to estimate gamma.
 // For gamma close to 1.0, RGB is linear. On profiles not supported, -1 is returned.
 
 cmsFloat64Number CMSEXPORT cmsDetectRGBProfileGamma(cmsHPROFILE hProfile, cmsFloat64Number threshold)

--- a/src/cmsio1.c
+++ b/src/cmsio1.c
@@ -578,7 +578,7 @@ Error:
     return NULL;
 }
 
-// Create an output MPE LUT from agiven profile. Version mismatches are handled here
+// Create an output MPE LUT from a given profile. Version mismatches are handled here
 cmsPipeline* CMSEXPORT _cmsReadOutputLUT(cmsHPROFILE hProfile, cmsUInt32Number Intent)
 {
     cmsTagTypeSignature OriginalType;

--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -183,6 +183,7 @@ cmsBool  isFloatMatrixIdentity(const cmsMAT3* a)
 
        return TRUE;
 }
+
 // if two adjacent matrices are found, multiply them. 
 static
 cmsBool _MultiplyMatrix(cmsPipeline* Lut)
@@ -1928,7 +1929,7 @@ cmsBool CMSEXPORT _cmsOptimizePipeline(cmsContext ContextID,
     for (mpe = cmsPipelineGetPtrToFirstStage(*PtrLut);
         mpe != NULL;
         mpe = cmsStageNext(mpe)) {
-        if (cmsStageType(mpe) == cmsSigNamedColorElemType) return FALSE;
+            if (cmsStageType(mpe) == cmsSigNamedColorElemType) return FALSE;
     }
 
     // Try to get rid of identities and trivial conversions.

--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -1772,7 +1772,7 @@ cmsBool OptimizeMatrixShaper(cmsPipeline** Lut, cmsUInt32Number Intent, cmsUInt3
         _cmsStageToneCurvesData* mpeC2 = (_cmsStageToneCurvesData*) cmsStageData(Curve2);
 
         // In this particular optimization, cache does not help as it takes more time to deal with
-        // the cache that with the pixel handling
+        // the cache than with the pixel handling
         *dwFlags |= cmsFLAGS_NOCACHE;
 
         // Setup the optimizarion routines

--- a/src/cmsps2.c
+++ b/src/cmsps2.c
@@ -557,7 +557,7 @@ void EmitNGamma(cmsIOHANDLER* m, cmsUInt32Number n, cmsToneCurve* g[], const cha
         }
         else {
             snprintf(buffer, sizeof(buffer), "%s%d", nameprefix, (int) i);
-        buffer[sizeof(buffer)-1] = '\0';
+            buffer[sizeof(buffer)-1] = '\0';
             Emit1Gamma(m, g[i], buffer);
         }
     }

--- a/src/cmssamp.c
+++ b/src/cmssamp.c
@@ -123,7 +123,7 @@ cmsBool  BlackPointAsDarkerColorant(cmsHPROFILE    hInput,
     // Convert black to Lab
     cmsDoTransform(xform, Black, &Lab, 1);
 
-    // Force it to be neutral, check for inconsistences
+    // Force it to be neutral, check for inconsistencies
     Lab.a = Lab.b = 0;
     if (Lab.L > 50 || Lab.L < 0) Lab.L = 0;
 

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -93,7 +93,7 @@ cmsBool RegisterTypesPlugin(cmsContext id, cmsPluginBase* Data, _cmsMemoryClient
     return TRUE;
 }
 
-// Return handler for a given type or NULL if not found. Shared between normal types and MPE. It first tries the additons 
+// Return handler for a given type or NULL if not found. Shared between normal types and MPE. It first tries the additions
 // made by plug-ins and then the built-in defaults.
 static
 cmsTagTypeHandler* GetHandler(cmsTagTypeSignature sig, _cmsTagTypeLinkedList* PluginLinkedList, _cmsTagTypeLinkedList* DefaultLinkedList)

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -4450,7 +4450,7 @@ void *Type_MPEclut_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, 
     clut = (_cmsStageCLutData*) mpe ->Data;
     for (i=0; i < clut ->nEntries; i++) {
 
-        if (!_cmsReadFloat32Number(io, &clut->Tab.TFloat[i])) goto Error;       
+        if (!_cmsReadFloat32Number(io, &clut->Tab.TFloat[i])) goto Error;
     }
 
     *nItems = 1;

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -517,7 +517,7 @@ struct _cmsContext_struct {
     struct _cmsContext_struct* Next;  // Points to next context in the new style
     _cmsSubAllocator* MemPool;        // The memory pool that stores context data
     
-    void* chunks[MemoryClientMax];    // array of pointers to client chunks. Memory itself is hold in the suballocator. 
+    void* chunks[MemoryClientMax];    // array of pointers to client chunks. Memory itself is held in the suballocator.
                                       // If NULL, then it reverts to global Context0
 
     _cmsMemPluginChunkType DefaultMemoryManager;  // The allocators used for creating the context itself. Cannot be overridden

--- a/testbed/testcms2.c
+++ b/testbed/testcms2.c
@@ -225,7 +225,7 @@ void TestMemoryLeaks(cmsBool ok)
 static cmsPluginMemHandler DebugMemHandler = {{ cmsPluginMagicNumber, 2060, cmsPluginMemHandlerSig, NULL },
                                                DebugMalloc, DebugFree, DebugRealloc, NULL, NULL, NULL };
 
-// Returnds a pointer to the memhandler plugin
+// Returns a pointer to the memhandler plugin
 void* PluginMemHandler(void)
 {
     return (void*) &DebugMemHandler;


### PR DESCRIPTION
Easiest to see what's been changed by looking at the diffs, I suppose.

---

Extracted these edits from [my own fork](https://github.com/GerHobbelt/thirdparty-lcms2.git) (based off another git repo, related to mupdf) during a manual source tree review with your master branch. Trivial stuff, really. 😊