### PR TITLE
tweak: nullify freed tags inside freeOneTag(), where it is more suitable

### DIFF
--- a/src/cmsio0.c
+++ b/src/cmsio0.c
@@ -1568,8 +1568,10 @@ void freeOneTag(_cmsICCPROFILE* Icc, cmsUInt32Number i)
             LocalTypeHandler.ICCVersion = Icc->Version;
             LocalTypeHandler.FreePtr(&LocalTypeHandler, Icc->TagPtrs[i]);
         }
-        else
-            _cmsFree(Icc->ContextID, Icc->TagPtrs[i]);
+		else {
+			_cmsFree(Icc->ContextID, Icc->TagPtrs[i]);
+		}
+		Icc->TagPtrs[i] = NULL;
     }
 }
 
@@ -1754,8 +1756,7 @@ void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
     // Return error and unlock the data
 Error:
 
-    freeOneTag(Icc, n);    
-    Icc->TagPtrs[n] = NULL;
+    freeOneTag(Icc, n);
     
     _cmsUnlockMutex(Icc->ContextID, Icc ->UsrMutex);
     return NULL;


### PR DESCRIPTION
nullify freed tags inside freeOneTag(), where it is more suitable than where it was done before (now we hit *both* spots where this call is used; slightly cleaner code this way)

Easiest to see what's been changed by looking at the diffs, I suppose.

---

Extracted these edits from [my own fork](https://github.com/GerHobbelt/thirdparty-lcms2.git) (based off another git repo, related to mupdf) during a manual source tree review with your master branch. Trivial stuff, really. 😊