### PR TITLE
Complete check for WIN32/WIN64 defines for various compilers to detect 64-bit Windows target builds (MSVC / PVS Studio)

### DIFF
--- a/include/lcms2.h
+++ b/include/lcms2.h
@@ -174,7 +174,7 @@ typedef cmsUInt32Number      cmsU16Fixed16Number;
 typedef int                  cmsBool;
 
 // Try to detect windows
-#if defined (_WIN32) || defined(_WIN64) || defined(WIN32) || defined(_WIN32_)
+#if defined (_WIN32) || defined(_WIN64) || defined(WIN32) || defined(WIN64) || defined(_WIN32_) //-V1040
 #  define CMS_IS_WINDOWS_ 1
 #endif
 


### PR DESCRIPTION
Ran into this one back when I was still using MSVC2019 and building 64-bit static libs; the V comment is to shut up [PVS Studio](https://pvs-studio.com/en/pvs-studio/).

Easiest to see what's been changed by looking at the diffs, I suppose.

---

Extracted these edits from [my own fork](https://github.com/GerHobbelt/thirdparty-lcms2.git) (based off another git repo, related to mupdf) during a manual source tree review with your master branch. Trivial stuff, really. 😊