### PR TITLE
Do not use the "register" keyword by default.

### DIFF
--- a/include/lcms2.h
+++ b/include/lcms2.h
@@ -61,8 +61,8 @@
 // Uncomment this for special windows mutex initialization (see lcms2_internal.h)
 // #define CMS_RELY_ON_WINDOWS_STATIC_MUTEX_INIT
 
-// Uncomment this to remove the "register" storage class
-// #define CMS_NO_REGISTER_KEYWORD 1
+// Comment this to use the deprecated "register" storage class
+#define CMS_NO_REGISTER_KEYWORD 1
 
 // ********** End of configuration toggles ******************************
 


### PR DESCRIPTION
It causes compilation errors in C++17 and newer, where the use of "register" is forbidden.

GCC and MSVC seem to be fine with it, but Xcode 15's Clang hard errors on it.