### PR TITLE
optimize the code in cmsFreeProfileSequenceDescription()

### DIFF
--- a/src/cmsnamed.c
+++ b/src/cmsnamed.c
@@ -817,15 +817,16 @@ void CMSEXPORT cmsFreeProfileSequenceDescription(cmsSEQ* pseq)
     if (pseq == NULL)
         return;
 
-    for (i=0; i < pseq ->n; i++) {
-        if (pseq->seq != NULL) {
+    if (pseq ->seq != NULL) {
+        for (i=0; i < pseq ->n; i++) {
             if (pseq ->seq[i].Manufacturer != NULL) cmsMLUfree(pseq ->seq[i].Manufacturer);
             if (pseq ->seq[i].Model != NULL) cmsMLUfree(pseq ->seq[i].Model);
             if (pseq ->seq[i].Description != NULL) cmsMLUfree(pseq ->seq[i].Description);
         }
+
+        _cmsFree(pseq ->ContextID, pseq ->seq);
     }
 
-    if (pseq ->seq != NULL) _cmsFree(pseq ->ContextID, pseq ->seq);
     _cmsFree(pseq -> ContextID, pseq);
 }
 


### PR DESCRIPTION
Hi, when I test the release version 2.15, I got the error below:
```txt
==12022==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000028 (pc 0x0000006a3e15 bp 0x7ffff47d3380 sp 0x7ffff47d32c0 T0)
==12022==The signal is caused by a READ memory access.
==12022==Hint: address points to the zero page.
    #0 0x6a3e15 in cmsFreeProfileSequenceDescription Little-CMS-lcms2.15/src/cmsnamed.c:818:40
    #1 0x6a4d99 in cmsDupProfileSequenceDescription Little-CMS-lcms2.15/src/cmsnamed.c:864:5
```
Based on simple analysis, it is because `pseq ->seq` is not checked in cmsFreeProfileSequenceDescription() of version 2.15.
I found that the above problem is fixed in https://github.com/mm2/Little-CMS/commit/ac9e8e16e6f19735b95e6f0e13940256c99aeecd, but the code could still be optimized:
if `pseq ->seq`  is NULL, then it is unnecessary to enter the loop so that we just need to check the pointer one time.