### PR TITLE
Not allow 0 as the size for memory allocation

### DIFF
--- a/src/cmserr.c
+++ b/src/cmserr.c
@@ -92,7 +92,8 @@ cmsBool   _cmsRegisterMemHandlerPlugin(cmsContext ContextID, cmsPluginBase* Plug
 static
 void* _cmsMallocDefaultFn(cmsContext ContextID, cmsUInt32Number size)
 {
-    if (size > MAX_MEMORY_FOR_ALLOC) return NULL;  // Never allow over maximum
+    // Never allow 0 or over maximum
+    if (size == 0 || size > MAX_MEMORY_FOR_ALLOC) return NULL;
 
     return (void*) malloc(size);
 


### PR DESCRIPTION
Hi, when I tested lcms 2.15, I got the error below:
```txt
==25874==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000fea70 at pc 0x00000066f1d8 bp 0x7ffda729c770 sp 0x7ffda729c768
READ of size 8 at 0x6020000fea70 thread T0
    #0 0x66f1d7 in cmsPipelineFree Little-CMS-lcms2.15/src/cmslut.c:1423:22
    #1 0x6f7df0 in Type_LUTA2B_Free Little-CMS-lcms2.15/src/cmstypes.c:2856:5
    #2 0x657117 in freeOneTag Little-CMS-lcms2.15/src/cmsio0.c:1558:13
    #3 0x65390b in cmsCloseProfile Little-CMS-lcms2.15/src/cmsio0.c:1583:9

0x6020000fea71 is located 0 bytes to the right of 1-byte region [0x6020000fea70,0x6020000fea71)
allocated by thread T0 here:
    #0 0x52988d in malloc
    #1 0x6164c9 in _cmsMallocDefaultFn Little-CMS-lcms2.15/src/cmserr.c:97:20
    #2 0x6174f3 in _cmsMalloc Little-CMS-lcms2.15/src/cmserr.c:267:12
    #3 0x6169ae in _cmsDupDefaultFn Little-CMS-lcms2.15/src/cmserr.c:171:11
    #4 0x61793f in _cmsDupMem Little-CMS-lcms2.15/src/cmserr.c:304:12
    #5 0x65c036 in cmsWriteRawTag Little-CMS-lcms2.15/src/cmsio0.c:2036:25
```
Based on the analysis, it is because the size argument of cmsWriteRawTag is 0, while (void *)malloc(0) can also return an address (Note: depends on the particular library implementation).
Consider the possible returned address is unknown and maybe dangerous operated by other instructions, it is better directly disallow 0 as the size for memory allocation to prevent the potential risk in time.