### PR TITLE
check whether xform->Lut is valid in cmsTransform2DeviceLink

### DIFF
--- a/src/cmsvirt.c
+++ b/src/cmsvirt.c
@@ -1196,6 +1196,9 @@ cmsHPROFILE CMSEXPORT cmsTransform2DeviceLink(cmsHTRANSFORM hTransform, cmsFloat
 
     _cmsAssert(hTransform != NULL);
 
+    // Check if the pipeline holding is valid
+    if (xform -> Lut == NULL) return NULL;
+
     // Get the first mpe to check for named color
     mpe = cmsPipelineGetPtrToFirstStage(xform ->Lut);
 


### PR DESCRIPTION
In cmsTransform2DeviceLink(), it does not check if `xform -> Lut` is valid, which can result in potential NULL dereference:
```txt
==27935==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000670a92 bp 0x7fffad69b910 sp 0x7fffad69b900 T0)
==27935==The signal is caused by a READ memory access.
==27935==Hint: address points to the zero page.
    #0 0x670a92 in cmsPipelineGetPtrToFirstStage Little-CMS-lcms2.15/src/cmslut.c:1639:18
    #1 0x6de22c in cmsTransform2DeviceLink Little-CMS-lcms2.15/src/cmsvirt.c:1079:11
```
The `xform -> Lut` can be NULL as cmsCreateExtendedTransform() will return a fake transform that sets `xform -> Lut` to NULL, when the flag is `cmsFLAGS_NULLTRANSFORM`.
> Note: here I suppose the valid of arguments should be checked by the caller, so I did not add checks to the related functions in cmslut.c.