### PR TITLE
add NULL check for mpe in Type_LUT8_Write

### DIFF
--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -1922,7 +1922,7 @@ cmsBool  Type_LUT8_Write(struct _cms_typehandler_struct* self, cmsIOHANDLER* io,
 
     // Disassemble the LUT into components.
     mpe = NewLUT -> Elements;
-    if (mpe ->Type == cmsSigMatrixElemType) {
+    if (mpe != NULL && mpe ->Type == cmsSigMatrixElemType) {
 
         if (mpe->InputChannels != 3 || mpe->OutputChannels != 3) return FALSE;
         MatMPE = (_cmsStageMatrixData*) mpe ->Data;


### PR DESCRIPTION
Fix a potential NULL dereference just like below:
```
==3959==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x0000006eaa47 bp 0x7fff68d66050 sp 0x7fff68d65d80 T0)
==3959==The signal is caused by a READ memory access.
==3959==Hint: address points to the zero page.
    #0 0x6eaa47 in Type_LUT8_Write Little-CMS-lcms2.15/src/cmstypes.c:1927:15
    #1 0x65610c in SaveTags Little-CMS-lcms2.15/src/cmsio0.c:1380:18
    #2 0x6548eb in cmsSaveProfileToIOhandler Little-CMS-lcms2.15/src/cmsio0.c:1453:10
    #3 0x656c0a in cmsSaveProfileToMem Little-CMS-lcms2.15/src/cmsio0.c:1539:11
```
This fix refers to the code of Type_LUT16_Write().