### PR TITLE
OptimizeMatrixShaper: check the size of Matrix before copying it

### DIFF
--- a/src/cmsopt.c
+++ b/src/cmsopt.c
@@ -1728,6 +1728,8 @@ cmsBool OptimizeMatrixShaper(cmsPipeline** Lut, cmsUInt32Number Intent, cmsUInt3
 
                      _cmsStageMatrixData* Data = (_cmsStageMatrixData*)cmsStageData(Matrix1);
 
+                     if (Matrix1->InputChannels != 3 || Matrix1->OutputChannels != 3) return FALSE;
+
                      // Copy the matrix to our result
                      memcpy(&res, Data->Double, sizeof(res));
 


### PR DESCRIPTION
As res is a 3x3 Matrix, it is better to check the source data before copying to res.
Otherwise, the error like below may happen:
```
==3860==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60300023edc8 at pc 0x000000528c37 bp 0x7fffd1f029b0 sp 0x7fffd1f02178
READ of size 72 at 0x60300023edc8 thread T0
    #0 0x528c36 in __asan_memcpy
    #1 0x743690 in OptimizeMatrixShaper Little-CMS-lcms2.15/src/cmsopt.c:1728:22
    #2 0x739785 in _cmsOptimizePipeline Little-CMS-lcms2.15/src/cmsopt.c:1961:17
    #3 0x6b9a8a in AllocEmptyTransform Little-CMS-lcms2.15/src/cmsxform.c:913:12
    #4 0x6b7f5e in cmsCreateExtendedTransform Little-CMS-lcms2.15/src/cmsxform.c:1181:13
    #5 0x6bc30e in cmsCreateMultiprofileTransformTHR Little-CMS-lcms2.15/src/cmsxform.c:1281:12
    #6 0x6bc76b in cmsCreateTransformTHR Little-CMS-lcms2.15/src/cmsxform.c:1322:12
    #7 0x6bc887 in cmsCreateTransform Little-CMS-lcms2.15/src/cmsxform.c:1332:12

0x60300023edc8 is located 0 bytes to the right of 24-byte region [0x60300023edb0,0x60300023edc8)
allocated by thread T0 here:
    #0 0x52988d in malloc
    #1 0x6163f7 in _cmsMallocDefaultFn Little-CMS-lcms2.15/src/cmserr.c:98:20
    #2 0x617423 in _cmsMalloc Little-CMS-lcms2.15/src/cmserr.c:268:12
    #3 0x6168de in _cmsDupDefaultFn Little-CMS-lcms2.15/src/cmserr.c:172:11
    #4 0x61786f in _cmsDupMem Little-CMS-lcms2.15/src/cmserr.c:305:12
    #5 0x6659fb in MatrixElemDup Little-CMS-lcms2.15/src/cmslut.c:352:44
    #6 0x66db80 in cmsStageDup Little-CMS-lcms2.15/src/cmslut.c:1260:25
    #7 0x6708c9 in cmsPipelineCat Little-CMS-lcms2.15/src/cmslut.c:1620:56
    #8 0x60d2b2 in DefaultICCintents Little-CMS-lcms2.15/src/cmscnvrt.c:616:14
    #9 0x6125e6 in BlackPreservingKOnlyIntents Little-CMS-lcms2.15/src/cmscnvrt.c:764:19
    #10 0x60de3f in _cmsLinkProfiles Little-CMS-lcms2.15/src/cmscnvrt.c:1137:12
    #11 0x6b7d4a in cmsCreateExtendedTransform Little-CMS-lcms2.15/src/cmsxform.c:1165:11
    #12 0x6bc30e in cmsCreateMultiprofileTransformTHR Little-CMS-lcms2.15/src/cmsxform.c:1281:12
    #13 0x6bc76b in cmsCreateTransformTHR Little-CMS-lcms2.15/src/cmsxform.c:1322:12
    #14 0x6bc887 in cmsCreateTransform Little-CMS-lcms2.15/src/cmsxform.c:1332:12
```