### PR TITLE
add NULL checks to cmsStageSampleCLutFloat()

### DIFF
--- a/src/cmslut.c
+++ b/src/cmslut.c
@@ -817,7 +817,13 @@ cmsBool CMSEXPORT cmsStageSampleCLutFloat(cmsStage* mpe, cmsSAMPLERFLOAT Sampler
     cmsUInt32Number nInputs, nOutputs;
     cmsUInt32Number* nSamples;
     cmsFloat32Number In[MAX_INPUT_DIMENSIONS+1], Out[MAX_STAGE_CHANNELS];
-    _cmsStageCLutData* clut = (_cmsStageCLutData*) mpe->Data;
+    _cmsStageCLutData* clut;
+
+    if (mpe == NULL) return FALSE;
+
+    clut = (_cmsStageCLutData*) mpe->Data;
+
+    if (clut == NULL) return FALSE;
 
     nSamples = clut->Params ->nSamples;
     nInputs  = clut->Params ->nInputs;


### PR DESCRIPTION
Fix the potential NULL dereferenced issues of cmsStageSampleCLutFloat() by adding NULL checks just like cmsStageSampleCLut16bit().