### PR TITLE
feat: configure dependabot to update workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #423

Similarly to discussed in the issue, this PR configures Dependabot to create a single monthly PR with any version updates on your GitHub Actions.