### PR TITLE
Fix various typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,12 +4,12 @@
 New import .CUBE files as RGB devicelinks
 New Read/Write MHC2 tags for Windows GPU access
 New Support for UTF8 on multilocalized unicode functions
-New Suppot for OkLab color space, built-in and formatter.
+New Support for OkLab color space, built-in and formatter.
 Improved floating point transforms float -> integer are now honored as float
 Improved MSYS2, mingw is now supported
 Improved proferred CMM, platform and creator now survives profile edition.
 Fixed tificc now can deal with Lab TIFF
-Fixed code can now be compiled by a C++17 compiler, "register" keywork use detected at compile time.
+Fixed code can now be compiled by a C++17 compiler, "register" keyword use detected at compile time.
 Fixed Reverted postcript creation that corrupted some interpreters.
 
 -----------------------
@@ -61,7 +61,7 @@ Bug & typos fixing (thanks to many reporters and contributors)
 -----------------------
 2.12 Maintenance release
 -----------------------
-Added new build-in sigmoidal tone curve
+Added new built-in sigmoidal tone curve
 Added XCode 12 project
 Added support for multichannel input up to 15 channels
 Fix LUT8 write matrix

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security updates are applied only to the latest release.
 
 ## Reporting a Vulnerability
 
-LittleCMS is located deep in the Linux dependency tree. So, security issues are real and should be addressed. The proposed process is quite simple, if you detect a potential security issue and you are able to create a patch, please send us the patch to analyse. We have an extensive test bed of apps and utilities using lcms, so we can check if all those goes fine. If you don’t want to create a patch and only want to report the vulnerability, thats ok too.  and we will be very gratefull. Just contact us.
+LittleCMS is located deep in the Linux dependency tree. So, security issues are real and should be addressed. The proposed process is quite simple, if you detect a potential security issue and you are able to create a patch, please send us the patch to analyse. We have an extensive test bed of apps and utilities using lcms, so we can check if all those goes fine. If you don’t want to create a patch and only want to report the vulnerability, that's ok too.  And we will be very grateful. Just contact us.
 
 **Please avoid public advisories if possible, as doing that, hints how to use the flaw for malicious use**.
 

--- a/configure
+++ b/configure
@@ -7489,7 +7489,7 @@ fi
 
 # Use ARFLAGS variable as AR's operation code to sync the variable naming with
 # Automake.  If both AR_FLAGS and ARFLAGS are specified, AR_FLAGS should have
-# higher priority because thats what people were doing historically (setting
+# higher priority because that's what people were doing historically (setting
 # ARFLAGS for automake and AR_FLAGS for libtool).  FIXME: Make the AR_FLAGS
 # variable obsoleted/removed.
 
@@ -12764,7 +12764,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directores which are
+  # Ideally, we could use ldconfig to report *all* directories which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -16768,7 +16768,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directores which are
+  # Ideally, we could use ldconfig to report *all* directories which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,

--- a/plugins/fast_float/include/lcms2_fast_float.h
+++ b/plugins/fast_float/include/lcms2_fast_float.h
@@ -36,7 +36,7 @@ extern "C" {
 
 // Uncomment this if you want to avoid SSE2 entirely.
 // Default is commented out. There are two kernels, one is vectorized and the other is not.
-// On inizialization, there is a SSE2 detection. If the SSE2 detection succeeds, then the vectorized code is selected.
+// On initialization, there is a SSE2 detection. If the SSE2 detection succeeds, then the vectorized code is selected.
 // If the CPU is old and does not support SSE2, then the non-vectorized  code is used.
 // If you define the toggle, there is no detection and the non-vectorized kernel is always used.
 

--- a/plugins/fast_float/src/fast_float_15mats.c
+++ b/plugins/fast_float/src/fast_float_15mats.c
@@ -52,7 +52,7 @@ typedef struct {
        // The context
        cmsContext ContextID;
 
-       // Poits to the raw, unaligned memory
+       // Points to the raw, unaligned memory
        void * real_ptr;
 
 

--- a/plugins/threaded/src/threaded_scheduler.c
+++ b/plugins/threaded/src/threaded_scheduler.c
@@ -78,7 +78,7 @@ void  _cmsThrScheduler(struct _cmstransform_struct* CMMcargo,
     // All seems ok so far
     if (_cmsThrSplitWork(&master, nSlices, slices))
     {
-        // Work is splitted. Create threads
+        // Work is split. Create threads
         cmsUInt32Number i;
 
         for (i = 1; i < nSlices; i++)

--- a/src/cmscgats.c
+++ b/src/cmscgats.c
@@ -1690,7 +1690,7 @@ cmsBool AllocateDataSet(cmsIT8* it8)
         return FALSE;
     }
     else {
-        // Some dumb analizers warns of possible overflow here, just take a look couple of lines above.
+        // Some dumb analyzers warns of possible overflow here, just take a look couple of lines above.
         t->Data = (char**)AllocChunk(it8, ((cmsUInt32Number)t->nSamples + 1) * ((cmsUInt32Number)t->nPatches + 1) * sizeof(char*));
         if (t->Data == NULL) {
 

--- a/src/cmsintrp.c
+++ b/src/cmsintrp.c
@@ -495,7 +495,7 @@ void TrilinearInterpFloat(const cmsFloat32Number Input[],
     py = fclamp(Input[1]) * p->Domain[1];
     pz = fclamp(Input[2]) * p->Domain[2];
 
-    x0 = (int) floor(px); fx = px - (cmsFloat32Number) x0;  // We need full floor funcionality here
+    x0 = (int) floor(px); fx = px - (cmsFloat32Number) x0;  // We need full floor functionality here
     y0 = (int) floor(py); fy = py - (cmsFloat32Number) y0;
     z0 = (int) floor(pz); fz = pz - (cmsFloat32Number) z0;
 

--- a/src/cmslut.c
+++ b/src/cmslut.c
@@ -1080,7 +1080,7 @@ cmsStage* _cmsStageNormalizeFromLabFloat(cmsContext ContextID)
     return mpe;
 }
 
-// Fom XYZ to floating point PCS
+// From XYZ to floating point PCS
 cmsStage* _cmsStageNormalizeFromXyzFloat(cmsContext ContextID)
 {
 #define n (32768.0/65535.0)

--- a/src/cmsnamed.c
+++ b/src/cmsnamed.c
@@ -569,7 +569,7 @@ cmsUInt32Number CMSEXPORT cmsMLUgetASCII(const cmsMLU* mlu,
     if (BufferSize < ASCIIlen + 1)
         ASCIIlen = BufferSize - 1;
 
-    // Precess each character
+    // Process each character
     for (i=0; i < ASCIIlen; i++) {
 
         wchar_t wc = Wide[i];

--- a/src/cmsps2.c
+++ b/src/cmsps2.c
@@ -465,7 +465,7 @@ void Emit1Gamma(cmsIOHANDLER* m, cmsToneCurve* Table)
     // Bounds check
     EmitRangeCheck(m);
 
-    // Emit intepolation code
+    // Emit interpolation code
 
     // PostScript code                      Stack
     // ===============                      ========================
@@ -589,7 +589,7 @@ int OutputValueSampler(CMSREGISTER const cmsUInt16Number In[], CMSREGISTER cmsUI
     }
 
 
-    // Hadle the parenthesis on rows
+    // Handle the parenthesis on rows
 
     if (In[0] != sc ->FirstComponent) {
 

--- a/src/lcms2_internal.h
+++ b/src/lcms2_internal.h
@@ -439,7 +439,7 @@ cmsBool  _cmsRegisterTransformPlugin(cmsContext ContextID, cmsPluginBase* Plugin
 // Mutex
 cmsBool _cmsRegisterMutexPlugin(cmsContext ContextID, cmsPluginBase* Plugin);
 
-// Paralellization
+// Parallelization
 cmsBool _cmsRegisterParallelizationPlugin(cmsContext ContextID, cmsPluginBase* Plugin);
 
 // ---------------------------------------------------------------------------------------------------------
@@ -972,7 +972,7 @@ cmsBool           _cmsReadCHAD(cmsMAT3* Dest, cmsHPROFILE hProfile);
 
 // Link several profiles to obtain a single LUT modelling the whole color transform. Intents, Black point
 // compensation and Adaptation parameters may vary across profiles. BPC and Adaptation refers to the PCS
-// after the profile. I.e, BPC[0] refers to connexion between profile(0) and profile(1)
+// after the profile. I.e, BPC[0] refers to connection between profile(0) and profile(1)
 cmsPipeline* _cmsLinkProfiles(cmsContext         ContextID,
                               cmsUInt32Number    nProfiles,
                               cmsUInt32Number    TheIntents[],

--- a/testbed/testcms2.c
+++ b/testbed/testcms2.c
@@ -3597,7 +3597,7 @@ cmsInt32Number CheckMLU(void)
     // Now for performance, allocate an empty struct
     mlu = cmsMLUalloc(DbgThread(), 0);
 
-    // Fill it with several thousands of different lenguages
+    // Fill it with several thousands of different languages
     for (i=0; i < 4096; i++) {
 
         char Lang[3];
@@ -6549,7 +6549,7 @@ int CheckRGBPrimaries(void)
     cmsXYZ2xyY(&tripxyY.Green, &tripXYZ.Green);
     cmsXYZ2xyY(&tripxyY.Blue, &tripXYZ.Blue);
 
-    /* valus were taken from
+    /* values were taken from
     http://en.wikipedia.org/wiki/RGB_color_spaces#Specifications */
 
     if (!IsGoodFixed15_16("xRed", tripxyY.Red.x, 0.64) ||
@@ -8803,7 +8803,7 @@ int CheckSaveLinearizationDevicelink(void)
     if (hDeviceLink == NULL)
     {
         remove("lin_rgb.icc");
-        Fail("Could't open devicelink");
+        Fail("Couldn't open devicelink");
     }
 
     xform = cmsCreateTransform(hDeviceLink, TYPE_RGB_8, NULL, TYPE_RGB_8, INTENT_PERCEPTUAL, 0);

--- a/testbed/testplugin.c
+++ b/testbed/testplugin.c
@@ -72,9 +72,9 @@ cmsInt32Number CheckAllocContext(void)
      
 
 
-     cmsDeleteContext(c1);  // Should be deleted by using nomal malloc
+     cmsDeleteContext(c1);  // Should be deleted by using normal malloc
      cmsDeleteContext(c2);  // Should be deleted by using debug malloc
-     cmsDeleteContext(c3);  // Should be deleted by using nomal malloc
+     cmsDeleteContext(c3);  // Should be deleted by using normal malloc
      cmsDeleteContext(c4);  // Should be deleted by using debug malloc
 
      return 1;


### PR DESCRIPTION
Found via `codespell -q3 -S "*.pdf,./m4,./ltmain.sh" -L ake,clen,htmp,maked,mis,ntemp,pich`