### PR TITLE
Keep src tree clean by running tests in the build directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get -y install build-essential python3-pip ninja-build
-          pip install meson==0.59.2
+          pip install meson==0.64.0
 
       - name: Build Ubuntu
         run: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install meson==0.59.2
+          pip install meson==0.64.0
 
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Build Windows

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'Little-CMS',
   'c',
   version: '2.16',
-  meson_version: '>=0.49.0',
+  meson_version: '>=0.64.0',
   # default_options: ['c_std=c99']
 )
 

--- a/testbed/meson.build
+++ b/testbed/meson.build
@@ -4,6 +4,17 @@ testcms_srcs = files(
   'zoo_icc.c',
 )
 
+# copy all iccs to the build dir and run the tests there
+iccs = [
+  'bad.icc', 'crayons.icc', 'new.icc', 'test2.icc', 'test4.icc', 'TestCLT.icc',
+  'bad_mpe.icc', 'ibm-t61.icc', 'test1.icc', 'test3.icc', 'test5.icc',
+  'toosmall.icc'
+]
+fs=import('fs')
+foreach icc : iccs
+  fs.copyfile(icc)
+endforeach
+
 testcms = executable(
   'testcms',
   testcms_srcs,
@@ -14,6 +25,6 @@ testcms = executable(
 test(
   'testcms',
   testcms,
-  workdir: meson.current_source_dir(),
+  workdir: meson.current_build_dir(),
   timeout: 600,
 )

--- a/utils/psicc/psicc.1
+++ b/utils/psicc/psicc.1
@@ -26,7 +26,6 @@ Input profile: Generates Color Space Array (CSA).
 Alternate way to set precision, number of CLUT points (CRD only).
 .TP
 .BI \-o\  profile
-.p
 Output profile: Generates Color Rendering Dictionary(CRD).
 .TP
 .BI \-t\  intent

--- a/utils/transicc/transicc.1
+++ b/utils/transicc/transicc.1
@@ -41,7 +41,6 @@ SoftProof intent (0,1,2,3) [defaults to 0].
 Terse output, intended for pipe usage.
 .TP
 .BI \-o\  profile
-.p
 Output profile (defaults to sRGB).
 .TP
 .B \-q


### PR DESCRIPTION
Two commits:
1. Running the tests in the build directory (and copying the necessary profiles there first). This avoids the creation of new.icc in the source directory. 
2. A small fix for the manpages. 