### PR TITLE
CI: add macOS arm64 job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ permissions: read-all
 jobs:
 
   Ubuntu:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner: [ ubuntu-20.04, ubuntu-latest ]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - name: Build Ubuntu
@@ -20,16 +23,6 @@ jobs:
           make 
           make check
 
-  Ubuntu-20-04:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build Ubuntu
-        run: |
-          ./configure --with-fastfloat --with-threaded
-          make 
-          make check
-          
   macOS:
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,37 +36,23 @@ jobs:
           make 
           make check        
     
-  Windows-64:
-    runs-on: windows-latest
-    
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ilammy/msvc-dev-cmd@v1   
-        with:
-            arch: x64
-                
-      - name: Build Windows 64 bit        
-        run: devenv .\Projects\VC2019\lcms2.sln /Rebuild "Release|x64" /Project testbed  
-        
-      - name: Run tests               
-        run: testbed\testbed.exe --chdir testbed
-            
-
-  Windows-32:
+  Windows:
+    strategy:
+      matrix:
+        arch: [ win32, x64 ]
     runs-on: windows-latest    
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1   
         with:
-            arch: win32
-            
-      - name: Build Windows 32 bit       
-        run: devenv .\Projects\VC2019\lcms2.sln /Rebuild "Release|Win32" /Project testbed  
+            arch: ${{ matrix.arch }}
 
-      - name: Run tests          
+      - name: Build Windows
+        run: devenv .\Projects\VC2019\lcms2.sln /Rebuild "Release|${{ matrix.arch }}" /Project testbed  
+
+      - name: Run tests               
         run: testbed\testbed.exe --chdir testbed
-                    
-        
+
   Ubuntu-meson:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   Ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Ubuntu
         run: |
           ./configure --with-fastfloat --with-threaded
@@ -23,18 +23,21 @@ jobs:
   Ubuntu-20-04:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Ubuntu
         run: |
           ./configure --with-fastfloat --with-threaded
           make 
           make check
           
-  MacOS:
-    runs-on: macos-latest
+  macOS:
+    strategy:
+      matrix:
+        runner: [ macos-12, macos-14 ]
+    runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build MacOS
+      - uses: actions/checkout@v4
+      - name: Build macOS
         run: |
           ./configure --with-fastfloat --with-threaded
           make 
@@ -44,7 +47,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1   
         with:
             arch: x64
@@ -59,7 +62,7 @@ jobs:
   Windows-32:
     runs-on: windows-latest    
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1   
         with:
             arch: win32
@@ -74,7 +77,7 @@ jobs:
   Ubuntu-meson:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install packages
         run: |
@@ -91,7 +94,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install packages
         run: |


### PR DESCRIPTION
See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source

Also bump actions/checkout from 2 to 4 while at it.