### PR TITLE
Disable warning

### DIFF
--- a/src/cmsxform.c
+++ b/src/cmsxform.c
@@ -297,7 +297,7 @@ void FloatXFORM(_cmsTRANSFORM* p,
 
                     // Certainly, out of gamut
                     for (c = 0; c < cmsMAXCHANNELS; c++)
-                        fOut[c] = ContextAlarmCodes->AlarmCodes[c] / 65535.0;
+                        fOut[c] = (cmsFloat32Number) (ContextAlarmCodes->AlarmCodes[c] / 65535.0);
 
                 }
                 else {

--- a/src/cmsxform.c
+++ b/src/cmsxform.c
@@ -297,7 +297,7 @@ void FloatXFORM(_cmsTRANSFORM* p,
 
                     // Certainly, out of gamut
                     for (c = 0; c < cmsMAXCHANNELS; c++)
-                        fOut[c] = (cmsFloat32Number) (ContextAlarmCodes->AlarmCodes[c] / 65535.0);
+                        fOut[c] = ContextAlarmCodes->AlarmCodes[c] / 65535.0F;
 
                 }
                 else {


### PR DESCRIPTION
We got a warning while building:

 warning C4244: "=": Konvertierung von "double" in "cmsFloat32Number", möglicher Datenverlust

so I added the cast for cmsFloat32Number.