### PR TITLE
fix bug detected at /Wall warning level in MSVC: comparison with the wrong variable: the slides[] pointer instead of the `nslices` count.

### DIFF
--- a/plugins/threaded/src/threaded_split.c
+++ b/plugins/threaded/src/threaded_split.c
@@ -147,7 +147,7 @@ void SlicePerLines(const _cmsWorkSlice* master, cmsInt32Number nslices,
     }
 
     // Add left lines because rounding
-    if (slices > 0) slices[nslices - 1].LineCount += TotalLines;
+    if (nslices > 0) slices[nslices - 1].LineCount += TotalLines;
 }
 
 // Per pixels on big blocks of one line
@@ -178,7 +178,7 @@ void SlicePerPixels(const _cmsWorkSlice* master, cmsInt32Number nslices,
     }
 
     // Add left pixels because rounding
-    if (slices > 0) slices[nslices - 1].PixelsPerLine += TotalPixels;
+    if (nslices > 0) slices[nslices - 1].PixelsPerLine += TotalPixels;
 }
 
 


### PR DESCRIPTION
:smile: as it says on the tin: 

> fix bug detected at /Wall warning level in MSVC: error C7664: '>': ordered comparison of pointer and integer zero ('_cmsWorkSlice []' and 'int')