### PR TITLE
Meson version fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,14 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get -y install build-essential python3-pip ninja-build
-          pip install meson==0.64.0
+          pip install meson==0.52.0
 
       - name: Build Ubuntu
         run: |
           meson setup build -Dfastfloat=true -Dthreaded=true
-          meson compile -C build
-          meson test -C build
+          cd build
+          ninja
+          meson test
 
   VisualStudio-meson:
     runs-on: windows-latest
@@ -77,12 +78,13 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install meson==0.64.0
+          pip install meson==0.52.0
 
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Build Windows
         run: |
           meson setup build
-          meson compile -C build
-          meson test -C build
+          cd build
+          ninja
+          meson test
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'Little-CMS',
   'c',
   version: '2.17',
-  meson_version: '>=0.49.0',
+  meson_version: '>=0.52.0',
   # default_options: ['c_std=c99']
 )
 

--- a/testbed/meson.build
+++ b/testbed/meson.build
@@ -10,7 +10,7 @@ iccs = [
   'bad_mpe.icc', 'ibm-t61.icc', 'test1.icc', 'test3.icc', 'test5.icc',
   'toosmall.icc'
 ]
-fs=import('fs')
+# fs=import('fs') - requires Meson >=0.53.0
 foreach icc : iccs
   # fs.copyfile(icc) # DOES NOT WORK ON FEDORA 40
   configure_file(input : icc,  output : icc, copy : true)


### PR DESCRIPTION
Require Meson &ge; 0.52 for `visibility:hidden`.  Disable unused import of `fs`, which requires Meson &ge; 0.53.  Downgrade Meson in CI to 0.52.