### PR TITLE
Fix windows thread deps detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,7 @@ if (
 endif
 
 
-if is_visual_studio    
+if host_machine.system() == 'windows'
     m_dep = []
     threads_dep = []
     deps = []


### PR DESCRIPTION
Using host_machine.system() instead of is_visual_studio
fixes #477