### PR TITLE
meson: ability to disable .so.version libraries

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,5 @@ option('tiff', type: 'feature', value: 'auto', description: 'Use LibTiff')
 option('utils', type: 'boolean', value: false, description: 'Build the utils')
 option('fastfloat', type: 'boolean', value: false, description: 'Build and install the fast float plugin, use only if GPL 3.0 is acceptable')
 option('threaded', type: 'boolean', value: false, description: 'Build and install the multi threaded plugin, use only if GPL 3.0 is acceptable')
+
+option('versionedlibs', type: 'boolean', value: true, description: 'Enable building of .so.version libraries, disable when crosscompiling for Android')

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,17 +41,29 @@ if host_machine.system() == 'windows'
     endif  
 endif
 
-liblcms2_lib = library(
-  'lcms2',
-  lcms2_srcs,
-  include_directories: inc_dirs,
-  gnu_symbol_visibility: 'hidden',
-  dependencies: deps,
-  c_args: cargs,
-  version: library_version,
-  # vs_module_defs: 'lcms2.def',
-  install: true,
-)
+if get_option('versionedlibs')
+  liblcms2_lib = library(
+    'lcms2',
+    lcms2_srcs,
+    include_directories: inc_dirs,
+    gnu_symbol_visibility: 'hidden',
+    dependencies: deps,
+    c_args: cargs,
+    version: library_version,
+    # vs_module_defs: 'lcms2.def',
+    install: true,
+  )
+else
+  liblcms2_lib = library(
+    'lcms2',
+    lcms2_srcs,
+    include_directories: inc_dirs,
+    gnu_symbol_visibility: 'hidden',
+    dependencies: deps,
+    c_args: cargs,
+    install: true,
+  )
+endif
 
 liblcms2_dep = declare_dependency(
   link_with: liblcms2_lib,


### PR DESCRIPTION
https://github.com/mm2/Little-CMS/issues/487

After thinking about it, I consider it is better to control behavior via the new option, as android build detection is not always trivial.