### PR TITLE
Discount Relative+BPC ink limiting for CMYK and cmsSigNcolorData color spaces

### DIFF
--- a/include/lcms2.h
+++ b/include/lcms2.h
@@ -1570,6 +1570,9 @@ CMSAPI cmsUInt32Number   CMSEXPORT cmsChannelsOf(cmsColorSpaceSignature ColorSpa
 // Get number of channels of color space or -1 if color space is not listed/supported
 CMSAPI cmsInt32Number CMSEXPORT cmsChannelsOfColorSpace(cmsColorSpaceSignature ColorSpace);
 
+// Determine if Relative renderings with Black Point Compensation should discount ink limiting for the color space
+CMSAPI cmsBool CMSEXPORT cmsDiscountRelativeInkLimiting(cmsColorSpaceSignature ColorSpace);
+
 // Build a suitable formatter for the colorspace of this profile. nBytes=1 means 8 bits, nBytes=2 means 16 bits. 
 CMSAPI cmsUInt32Number   CMSEXPORT cmsFormatterForColorspaceOfProfile(cmsHPROFILE hProfile, cmsUInt32Number nBytes, cmsBool lIsFloat);
 CMSAPI cmsUInt32Number   CMSEXPORT cmsFormatterForPCSOfProfile(cmsHPROFILE hProfile, cmsUInt32Number nBytes, cmsBool lIsFloat);

--- a/src/cmspcs.c
+++ b/src/cmspcs.c
@@ -939,6 +939,29 @@ cmsInt32Number CMSEXPORT cmsChannelsOfColorSpace(cmsColorSpaceSignature ColorSpa
     }
 }
 
+cmsBool CMSEXPORT cmsDiscountRelativeInkLimiting(cmsColorSpaceSignature ColorSpace)
+{
+    switch (ColorSpace) {
+    case cmsSigCmykData:
+    case cmsSig1colorData:
+    case cmsSig2colorData:
+    case cmsSig3colorData:
+    case cmsSig4colorData:
+    case cmsSig5colorData:
+    case cmsSig6colorData:
+    case cmsSig7colorData:
+    case cmsSig8colorData:
+    case cmsSig9colorData:
+    case cmsSig10colorData:
+    case cmsSig11colorData:
+    case cmsSig12colorData:
+    case cmsSig13colorData:
+    case cmsSig14colorData:
+    case cmsSig15colorData: return TRUE;
+    default: return FALSE;
+    }
+}
+
 /**
 * DEPRECATED: Provided for compatibility only
 */

--- a/src/cmssamp.c
+++ b/src/cmssamp.c
@@ -194,6 +194,7 @@ cmsBool BlackPointUsingPerceptualBlack(cmsCIEXYZ* BlackPoint, cmsHPROFILE hProfi
 cmsBool CMSEXPORT cmsDetectBlackPoint(cmsCIEXYZ* BlackPoint, cmsHPROFILE hProfile, cmsUInt32Number Intent, cmsUInt32Number dwFlags)
 {
     cmsProfileClassSignature devClass;
+    cmsColorSpaceSignature ColorSpace;
 
     // Make sure the device class is adequate
     devClass = cmsGetDeviceClass(hProfile);
@@ -267,9 +268,10 @@ cmsBool CMSEXPORT cmsDetectBlackPoint(cmsCIEXYZ* BlackPoint, cmsHPROFILE hProfil
     // That is about v2 profiles.
 
     // If output profile, discount ink-limiting and that's all
+    ColorSpace = cmsGetColorSpace(hProfile);
     if (Intent == INTENT_RELATIVE_COLORIMETRIC &&
         (cmsGetDeviceClass(hProfile) == cmsSigOutputClass) &&
-        (cmsGetColorSpace(hProfile)  == cmsSigCmykData))
+        (cmsDiscountRelativeInkLimiting(ColorSpace)))
         return BlackPointUsingPerceptualBlack(BlackPoint, hProfile);
 
     // Nope, compute BP using current intent.


### PR DESCRIPTION
Hi! I am working in the digital textile printing space where `CMYK+N` printer profiles are common (`CMYK+Orange+Violet`, `CMYK+Red+Green+Blue`, etc.). I've run into an issue where lcms fails to detect the black point for the Relative Colorimetric intent on `CMYK+N` ICC profiles.

For example, converting the colors `RGB8(0,0,0)` (black) and `RGB8(36,36,36)` (dark gray) from `sRGB` to a `CMYK+3` profile using `Relative+BPC` should produce 2 distinct grays, but lcms outputs the same color for both samples. This is in contrast to the Adobe BPC implementation in Photoshop that does the same transform but produces 2 distinct grays.

I believe I have traced the issue to the `cmsDetectBlackPoint` function in `cmssamp.c`: it appears as though lcms currently uses the Perceptual black point for `Relative+BPC` transforms _only on CMYK profiles_. I believe the Perceptual black point should also be used for `Relative+BPC` transforms on `CMYK+N` profiles as well.

In this patch, I have extended the `cmsDetectBlackPoint` function to use the Perceptual black point for `cmsSigCmykData` color spaces _AND_ all the `cmsSigNcolorData` color spaces. However, I'm not sure if _all_ of these color spaces should be included or if any additional color spaces should be included as well.

I have tested this patch on `cmsSig6-8colorData` output profiles (`CMYK+2`..`CMYK+4`) and found the results to be congruent with Adobe Photoshop. I am happy to provide `CMYK+N` profiles for testing if it is helpful.