### PR TITLE
CI: Enable CI workflow for testing on Windows ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
             runner: windows-latest
           - arch: x64
             runner: windows-latest
-          # - arch: arm64
-          #   runner: windows-11-arm  
+          - arch: arm64
+            runner: windows-11-arm  
 
     runs-on: ${{ matrix.runner }}
     steps:
@@ -155,8 +155,8 @@ jobs:
             runner: windows-latest
           - arch: x64
             runner: windows-latest
-          # - arch: ARM64
-          #   runner: windows-11-arm
+          - arch: ARM64
+            runner: windows-11-arm
 
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
**PR Description:**

- The PR adds support for building and testing LCMS on Windows ARM64 CI 