### PR TITLE
Check _MSVC_LANG so 'register' is dropped under MSVC (fixes C5033)

### DIFF
--- a/include/lcms2.h
+++ b/include/lcms2.h
@@ -86,8 +86,10 @@
 
 #ifndef CMS_USE_CPP_API
 #   ifdef __cplusplus
-#       if __cplusplus >= 201703L
-#            define CMS_NO_REGISTER_KEYWORD 1  
+        // MSVC keeps __cplusplus at 199711L unless /Zc:__cplusplus is passed, so also
+        // honor _MSVC_LANG; otherwise the C++17 'register' removal below never triggers.
+#       if (__cplusplus >= 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#            define CMS_NO_REGISTER_KEYWORD 1
 #       endif
 extern "C" {
 #   endif


### PR DESCRIPTION
### Issue
`lcms2.h` strips the C++17-removed `register` keyword only when `__cplusplus >= 201703L`

MSVC pins `__cplusplus` to `199711L` unless `/Zc:__cplusplus` is passed, so the guard misses and the `CMSREGISTER` prototypes emit **C5033** in C++17+ MSVC builds that don't set the flag (such as C++/WinRT).

###  Fix
Also accept `_MSVC_LANG >= 201703L`, which MSVC always sets to the active `/std` level. No change for other compilers or for C.

###  Verified 
Built with `cl /std:c++17 /W4` (no `/Zc:__cplusplus`)
Six instances of warning C5033 have been eliminated