### PR TITLE
Fix for UnrollAnyWordsPremul when extra channels are present

### DIFF
--- a/src/cmspack.c
+++ b/src/cmspack.c
@@ -573,7 +573,8 @@ cmsUInt8Number* UnrollAnyWordsPremul(CMSREGISTER _cmsTRANSFORM* info,
    cmsUInt32Number SwapEndian  = T_ENDIAN16(info -> InputFormat);
    cmsUInt32Number DoSwap      = T_DOSWAP(info ->InputFormat);
    cmsUInt32Number Reverse     = T_FLAVOR(info ->InputFormat);
-   cmsUInt32Number SwapFirst   = T_SWAPFIRST(info -> InputFormat);   
+   cmsUInt32Number SwapFirst   = T_SWAPFIRST(info -> InputFormat);
+   cmsUInt32Number Extra       = T_EXTRA(info -> InputFormat);
    cmsUInt32Number ExtraFirst  = DoSwap ^ SwapFirst;
    cmsUInt32Number i;
 
@@ -581,7 +582,7 @@ cmsUInt8Number* UnrollAnyWordsPremul(CMSREGISTER _cmsTRANSFORM* info,
    cmsUInt32Number alpha_factor = _cmsToFixedDomain(alpha);
 
     if (ExtraFirst) {
-        accum += sizeof(cmsUInt16Number);
+        accum += Extra * sizeof(cmsUInt16Number);
     }
 
     for (i=0; i < nChan; i++) {
@@ -604,7 +605,7 @@ cmsUInt8Number* UnrollAnyWordsPremul(CMSREGISTER _cmsTRANSFORM* info,
     }
 
     if (!ExtraFirst) {
-        accum += sizeof(cmsUInt16Number);
+        accum += Extra * sizeof(cmsUInt16Number);
     }
 
     return accum;


### PR DESCRIPTION
I add skipping of extras as in UnrollAnyWords().

I had a problem with a TIFF image saved by Photoshop. Before using it in LittleCMS, I always convert the image from Planar to Chunky and tell LittleCMS that I don't want premultiplied alpha on output. I noticed the problem with the CMYK-to-RGB conversion.

I'm attaching a 16-bit CMYK TIFF with premultiplied alpha and an extra channel already converted to chunky with another software (Photoshop displays it correctly).

[testcard16_cmykp5.tif](https://github.com/user-attachments/files/29034335/testcard16_cmykp5.tif)
