### PR TITLE
Add missing allocation failure check

### DIFF
--- a/src/cmserr.c
+++ b/src/cmserr.c
@@ -681,7 +681,7 @@ void CMSEXPORT _cmsDestroyMutex(cmsContext ContextID, void* mtx)
 {
     _cmsMutexPluginChunkType* ptr = (_cmsMutexPluginChunkType*) _cmsContextGetClientChunk(ContextID, MutexPlugin);
 
-    if (ptr ->DestroyMutexPtr != NULL) {
+    if (ptr ->DestroyMutexPtr != NULL && mtx != NULL) {
 
         ptr ->DestroyMutexPtr(ContextID, mtx);
     }
@@ -691,7 +691,7 @@ cmsBool CMSEXPORT _cmsLockMutex(cmsContext ContextID, void* mtx)
 {
     _cmsMutexPluginChunkType* ptr = (_cmsMutexPluginChunkType*) _cmsContextGetClientChunk(ContextID, MutexPlugin);
 
-    if (ptr ->LockMutexPtr == NULL) return TRUE;
+    if (ptr ->LockMutexPtr == NULL || mtx == NULL) return TRUE;
 
     return ptr ->LockMutexPtr(ContextID, mtx);
 }
@@ -700,7 +700,7 @@ void CMSEXPORT _cmsUnlockMutex(cmsContext ContextID, void* mtx)
 {
     _cmsMutexPluginChunkType* ptr = (_cmsMutexPluginChunkType*) _cmsContextGetClientChunk(ContextID, MutexPlugin);
 
-    if (ptr ->UnlockMutexPtr != NULL) {
+    if (ptr ->UnlockMutexPtr != NULL && mtx != NULL) {
 
         ptr ->UnlockMutexPtr(ContextID, mtx);
     }

--- a/src/cmserr.c
+++ b/src/cmserr.c
@@ -590,6 +590,7 @@ static
 void* defMtxCreate(cmsContext id)
 {
     _cmsMutex* ptr_mutex = (_cmsMutex*) _cmsMalloc(id, sizeof(_cmsMutex));
+    if (ptr_mutex == NULL) return NULL;
     _cmsInitMutexPrimitive(ptr_mutex);
     return (void*) ptr_mutex;   
 }


### PR DESCRIPTION
This was discovered by libvips in https://github.com/libvips/libvips/pull/5129, which adds a fuzzer that deterministically injects allocation failures.

<details>
  <summary>Details</summary>

```console
AddressSanitizer:DEADLYSIGNAL
=================================================================
==9==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000020 (pc 0x7fa653c8d7fc bp 0x7ffdee5f7400 sp 0x7ffdee5f73d0 T0)
==9==The signal is caused by a WRITE memory access.
==9==Hint: address points to the zero page.
SCARINESS: 10 (null-deref)
    #0 0x7fa653c8d7fc in __pthread_mutex_init (/lib/x86_64-linux-gnu/libc.so.6+0x9f7fc) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #1 0x5576ed9a774c in _cmsInitMutexPrimitive /src/lcms/build/../src/lcms2_internal.h:342:12
    #2 0x5576ed9a774c in defMtxCreate /src/lcms/build/../src/cmserr.c:593:5
    #3 0x5576ed9aa07c in cmsCreateProfilePlaceholder /src/lcms/build/../src/cmsio0.c:625:22
    #4 0x5576ed9f41f3 in cmsCreateRGBProfileTHR /src/lcms/build/../src/cmsvirt.c:113:12
    #5 0x5576ed9f5acc in cmsCreateLab4ProfileTHR /src/lcms/build/../src/cmsvirt.c:535:16
    #6 0x5576ed1747d7 in vips_icc_import_build /src/libvips/build/../libvips/colour/icc_transform.c:817:22
    #7 0x5576ecf46dc9 in vips_object_build /src/libvips/build/../libvips/iofuncs/object.c:372:6
    #8 0x5576ecf22b53 in LLVMFuzzerTestOneInput /src/libvips/build/../fuzz/vips_fuzzer.cc:445:8
    #9 0x5576ecdbe2cd in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
    #10 0x5576ecdbd905 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:516:7
    #11 0x5576ecdbfc42 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:834:7
    #12 0x5576ecdbff48 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:872:3
    #13 0x5576ecdaede5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:917:6
    #14 0x5576ecddaa42 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #15 0x7fa653c181c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #16 0x7fa653c1828a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #17 0x5576ecda2134 in _start (/out/vips_oom_fuzzer+0x965134)
```
</details>