### PR TITLE
Fix UnrollPlanarWordsPremul() skipping only 1 plane instead of Extra planes

### DIFF
--- a/src/cmspack.c
+++ b/src/cmspack.c
@@ -659,15 +659,16 @@ cmsUInt8Number* UnrollPlanarWordsPremul(CMSREGISTER _cmsTRANSFORM* info,
     cmsUInt32Number SwapFirst = T_SWAPFIRST(info->InputFormat);
     cmsUInt32Number Reverse= T_FLAVOR(info ->InputFormat);
     cmsUInt32Number SwapEndian = T_ENDIAN16(info -> InputFormat);
+    cmsUInt32Number Extra = T_EXTRA(info -> InputFormat);
     cmsUInt32Number i;
     cmsUInt32Number ExtraFirst = DoSwap ^ SwapFirst;
     cmsUInt8Number* Init = accum;
-    
+
     cmsUInt16Number alpha = (ExtraFirst ? ((cmsUInt16Number*)accum)[0] : ((cmsUInt16Number*)accum)[nChan * Stride / 2]);
     cmsUInt32Number alpha_factor = _cmsToFixedDomain(alpha);
 
     if (ExtraFirst) {
-        accum += Stride;
+        accum += Extra * Stride;
     }
 
     for (i=0; i < nChan; i++) {


### PR DESCRIPTION
`UnrollPlanarWordsPremul()` in `src/cmspack.c` computes `ExtraFirst` but never reads `T_EXTRA(info->InputFormat)`. When `ExtraFirst` is set it advances `accum` by a single `Stride`, regardless of how many extra (non-color) planes are actually declared. For formats with `Extra > 1` this shifts every subsequent color-channel read one plane early and leaves the last color channel unread, corrupting the unrolled pixel.

The chunky sibling `UnrollAnyWordsPremul()` had the identical bug and was already fixed by adding an `Extra` local and multiplying it into the pre-skip offset (`accum += Extra * sizeof(cmsUInt16Number)`). This PR applies the equivalent fix to the planar function:

```c
cmsUInt32Number Extra = T_EXTRA(info -> InputFormat);
...
if (ExtraFirst) {
    accum += Extra * Stride;
}
```

Reproduced with a formatter-dispatch harness for `COLORSPACE_SH(PT_CMYK)|CHANNELS_SH(4)|BYTES_SH(2)|PLANAR_SH(1)|EXTRA_SH(2)|PREMUL_SH(1)|DOSWAP_SH(1)` (2 extra planes ahead of 4 color planes): before the fix `wIn` came out as `{0x5555,0x4444,0x3333,0x2222}` instead of the correct `{0x6666,0x5555,0x4444,0x3333}`, with the K channel never read at all. After the fix, a 5-case regression suite covering `Extra=1/2/3` with both `ExtraFirst` settings (including the pre-existing, most common `Extra=1` case, and the already-correct `!ExtraFirst` path) all pass with no behavior change to previously-correct cases.