### PR TITLE
Fix write side of wchar_t <-> UTF-16 conversion for supplementary-plane code points

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 -----------------------
 2.20 Ongoing
 -----------------------
+Fix write side of wchar_t <-> UTF-16 conversion on platforms with 32-bit wchar_t, issue #180
 
 -----------------------
 2.19.1 hot fix

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -1784,7 +1784,7 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
     cmsUInt32Number SizeOfHeader;
     cmsUInt32Number  Len, Offset;
     cmsUInt32Number  i;
-    wchar_t*         Block;
+    wchar_t*         Block = NULL;
     cmsUInt32Number  BeginOfThisString, EndOfThisString, LargestPosition;
     cmsUInt32Number* RawBegin = NULL;   // Per-entry on-disk begin, in UTF-16 code units
     cmsUInt32Number* RawLen = NULL;     // Per-entry on-disk length, in UTF-16 code units
@@ -1872,16 +1872,11 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
         // with an invalid marker up front (instead of calloc's 0) makes that gap
         // distinguishable from a real, valid index 0 below.
         UnitToWChar = (cmsUInt32Number*) _cmsMalloc(self ->ContextID, (NumOfWchar + 1) * sizeof(cmsUInt32Number));
-        if (UnitToWChar == NULL) {
-            _cmsFree(self->ContextID, Block);
-            goto Error;
-        }
+        if (UnitToWChar == NULL) goto Error;
+
         memset(UnitToWChar, 0xff, (NumOfWchar + 1) * sizeof(cmsUInt32Number));
 
-        if (!convert_utf16_to_utf32_indexed(io, NumOfWchar, Block, UnitToWChar)) {
-            _cmsFree(self->ContextID, Block);
-            goto Error;
-        }
+        if (!convert_utf16_to_utf32_indexed(io, NumOfWchar, Block, UnitToWChar)) goto Error;
     }
 
     // Translate each entry's on-disk position into indices into the decoded Block,
@@ -1928,6 +1923,7 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
     return (void*) mlu;
 
 Error:
+    if (Block) _cmsFree(self ->ContextID, Block);
     if (RawBegin) _cmsFree(self ->ContextID, RawBegin);
     if (RawLen) _cmsFree(self ->ContextID, RawLen);
     if (UnitToWChar) _cmsFree(self ->ContextID, UnitToWChar);

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -128,10 +128,31 @@ cmsINLINE cmsUInt32Number surrogate_to_utf32(cmsUInt32Number high, cmsUInt32Numb
     return (high << 10) + low - 0x35fdc00;
 }
 
-// Number of on-disk UTF-16 code units required to encode n wchar_t elements.
-// On platforms where wchar_t is already 16 bits this is always n. On 32-bit
-// wchar_t platforms, any code point above 0xffff needs a UTF-16 surrogate
-// pair (two 16-bit units) to be represented on disk.
+// Sentinel returned by _cmsUtf16UnitsForScalar for a value that cannot be encoded as
+// a single valid UTF-16 scalar value on disk.
+#define _cmsUTF16_INVALID_SCALAR ((cmsUInt32Number) 0xffffffffu)
+
+// Classify a single code point for on-disk UTF-16 encoding: returns the number of
+// UTF-16 code units it needs (1 for the BMP, 2 for a surrogate pair), or the sentinel
+// above if the value is not representable at all -- either above the maximum valid
+// Unicode scalar value (U+10FFFF), or itself a surrogate code point (U+D800-U+DFFF),
+// which can only appear as one half of an on-disk pair, never as a scalar value in its
+// own right. Both counting and encoding go through this single classification so they
+// can never disagree with each other about how many units a given value takes.
+cmsINLINE cmsUInt32Number _cmsUtf16UnitsForScalar(cmsUInt32Number uc)
+{
+    if (uc > 0x10ffff) return _cmsUTF16_INVALID_SCALAR;
+    if (uc >= 0xd800 && uc <= 0xdfff) return _cmsUTF16_INVALID_SCALAR;
+    return (uc > 0xffff) ? 2 : 1;
+}
+
+// Number of on-disk UTF-16 code units required to encode n wchar_t elements, or
+// _cmsUTF16_INVALID_SCALAR if any of them isn't representable (see
+// _cmsUtf16UnitsForScalar). On platforms where wchar_t is already 16 bits this is
+// always n (no caller should be relying on validation happening on those platforms,
+// since there every code point already has to be pre-encoded as a surrogate pair by
+// whoever built the string). On 32-bit wchar_t platforms, any code point above 0xffff
+// needs a UTF-16 surrogate pair (two 16-bit units) to be represented on disk.
 cmsINLINE cmsUInt32Number _cmsCountUtf16Units(const wchar_t* Array, cmsUInt32Number n)
 {
     cmsUInt32Number i, count;
@@ -140,7 +161,10 @@ cmsINLINE cmsUInt32Number _cmsCountUtf16Units(const wchar_t* Array, cmsUInt32Num
         return n;
 
     for (count = 0, i = 0; i < n; i++) {
-        count += ((cmsUInt32Number) Array[i] > 0xffff) ? 2 : 1;
+
+        cmsUInt32Number Units = _cmsUtf16UnitsForScalar((cmsUInt32Number) Array[i]);
+        if (Units == _cmsUTF16_INVALID_SCALAR) return _cmsUTF16_INVALID_SCALAR;
+        count += Units;
     }
 
     return count;
@@ -148,7 +172,10 @@ cmsINLINE cmsUInt32Number _cmsCountUtf16Units(const wchar_t* Array, cmsUInt32Num
 
 // Reverse operation of convert_utf16_to_utf32 below: encode each of the n wchar_t
 // code points in Array as one or two UTF-16 code units, writing surrogate pairs
-// for anything above 0xffff (only reachable when wchar_t is 32 bits).
+// for anything above 0xffff (only reachable when wchar_t is 32 bits). Fails cleanly
+// (matching convert_utf16_to_utf32's "corrupted string" convention on the read side)
+// rather than emitting a structurally invalid surrogate pair or a lone unpaired
+// surrogate unit for a value _cmsUtf16UnitsForScalar rejects.
 cmsINLINE cmsBool convert_utf32_to_utf16(cmsIOHANDLER* io, cmsUInt32Number n, const wchar_t* Array)
 {
     cmsUInt32Number i;
@@ -156,8 +183,11 @@ cmsINLINE cmsBool convert_utf32_to_utf16(cmsIOHANDLER* io, cmsUInt32Number n, co
     for (i = 0; i < n; i++) {
 
         cmsUInt32Number uc = (cmsUInt32Number) Array[i];
+        cmsUInt32Number Units = _cmsUtf16UnitsForScalar(uc);
 
-        if (uc > 0xffff) {
+        if (Units == _cmsUTF16_INVALID_SCALAR) return FALSE;
+
+        if (Units == 2) {
 
             cmsUInt32Number v = uc - 0x10000;
             cmsUInt16Number high = (cmsUInt16Number) (0xd800 + (v >> 10));
@@ -1348,6 +1378,7 @@ cmsBool  Type_Text_Description_Write(struct _cms_typehandler_struct* self, cmsIO
     // elements whenever a code point above 0xffff needs to be encoded as a UTF-16
     // surrogate pair (only reachable on 32-bit wchar_t platforms).
     ucCount = _cmsCountUtf16Units(Wide, len_text);
+    if (ucCount == _cmsUTF16_INVALID_SCALAR) goto Error;
     // Compute an total tag size requirement
     len_tag_requirement = (8+4+len_text+4+4+2*ucCount+2+1+67);
     len_aligned = _cmsALIGNLONG(len_tag_requirement);
@@ -1973,8 +2004,15 @@ cmsBool  Type_MLU_Write(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, 
         if (WCharToUnit == NULL) return FALSE;
 
         for (k = 0, Units = 0; k < PoolWChars; k++) {
+
+            cmsUInt32Number ThisUnits = _cmsUtf16UnitsForScalar((cmsUInt32Number) WPool[k]);
+            if (ThisUnits == _cmsUTF16_INVALID_SCALAR) {
+                _cmsFree(self ->ContextID, WCharToUnit);
+                return FALSE;
+            }
+
             WCharToUnit[k] = Units;
-            Units += ((cmsUInt32Number) WPool[k] > 0xffff) ? 2 : 1;
+            Units += ThisUnits;
         }
         WCharToUnit[PoolWChars] = Units;
     }

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -118,6 +118,62 @@ cmsTagTypeHandler* GetHandler(cmsTagTypeSignature sig, _cmsTagTypeLinkedList* Pl
 }
 
 
+// Try to promote correctly to wchar_t when 32 bits
+cmsINLINE cmsBool is_surrogate(cmsUInt32Number uc) { return (uc - 0xd800u) < 2048u; }
+cmsINLINE cmsBool is_high_surrogate(cmsUInt32Number uc) { return (uc & 0xfffffc00) == 0xd800; }
+cmsINLINE cmsBool is_low_surrogate(cmsUInt32Number uc)  { return (uc & 0xfffffc00) == 0xdc00; }
+
+cmsINLINE cmsUInt32Number surrogate_to_utf32(cmsUInt32Number high, cmsUInt32Number low)
+{
+    return (high << 10) + low - 0x35fdc00;
+}
+
+// Number of on-disk UTF-16 code units required to encode n wchar_t elements.
+// On platforms where wchar_t is already 16 bits this is always n. On 32-bit
+// wchar_t platforms, any code point above 0xffff needs a UTF-16 surrogate
+// pair (two 16-bit units) to be represented on disk.
+cmsINLINE cmsUInt32Number _cmsCountUtf16Units(const wchar_t* Array, cmsUInt32Number n)
+{
+    cmsUInt32Number i, count;
+
+    if (sizeof(wchar_t) <= sizeof(cmsUInt16Number) || Array == NULL)
+        return n;
+
+    for (count = 0, i = 0; i < n; i++) {
+        count += ((cmsUInt32Number) Array[i] > 0xffff) ? 2 : 1;
+    }
+
+    return count;
+}
+
+// Reverse operation of convert_utf16_to_utf32 below: encode each of the n wchar_t
+// code points in Array as one or two UTF-16 code units, writing surrogate pairs
+// for anything above 0xffff (only reachable when wchar_t is 32 bits).
+cmsINLINE cmsBool convert_utf32_to_utf16(cmsIOHANDLER* io, cmsUInt32Number n, const wchar_t* Array)
+{
+    cmsUInt32Number i;
+
+    for (i = 0; i < n; i++) {
+
+        cmsUInt32Number uc = (cmsUInt32Number) Array[i];
+
+        if (uc > 0xffff) {
+
+            cmsUInt32Number v = uc - 0x10000;
+            cmsUInt16Number high = (cmsUInt16Number) (0xd800 + (v >> 10));
+            cmsUInt16Number low  = (cmsUInt16Number) (0xdc00 + (v & 0x3ff));
+
+            if (!_cmsWriteUInt16Number(io, high)) return FALSE;
+            if (!_cmsWriteUInt16Number(io, low))  return FALSE;
+        }
+        else {
+            if (!_cmsWriteUInt16Number(io, (cmsUInt16Number) uc)) return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
 // Auxiliary to convert UTF-32 to UTF-16 in some cases
 static
 cmsBool _cmsWriteWCharArray(cmsIOHANDLER* io, cmsUInt32Number n, const wchar_t* Array)
@@ -127,21 +183,14 @@ cmsBool _cmsWriteWCharArray(cmsIOHANDLER* io, cmsUInt32Number n, const wchar_t* 
     _cmsAssert(io != NULL);
     _cmsAssert(!(Array == NULL && n > 0));
 
+    if (sizeof(wchar_t) > sizeof(cmsUInt16Number) && Array != NULL)
+        return convert_utf32_to_utf16(io, n, Array);
+
     for (i=0; i < n; i++) {
         if (!_cmsWriteUInt16Number(io, (cmsUInt16Number) Array[i])) return FALSE;
     }
 
     return TRUE;
-}
-
-// Try to promote correctly to wchar_t when 32 bits
-cmsINLINE cmsBool is_surrogate(cmsUInt32Number uc) { return (uc - 0xd800u) < 2048u; }
-cmsINLINE cmsBool is_high_surrogate(cmsUInt32Number uc) { return (uc & 0xfffffc00) == 0xd800; }
-cmsINLINE cmsBool is_low_surrogate(cmsUInt32Number uc)  { return (uc & 0xfffffc00) == 0xdc00; }
-
-cmsINLINE cmsUInt32Number surrogate_to_utf32(cmsUInt32Number high, cmsUInt32Number low)
-{
-    return (high << 10) + low - 0x35fdc00;
 }
 
 cmsINLINE cmsBool convert_utf16_to_utf32(cmsIOHANDLER* io, cmsInt32Number n, wchar_t* output)
@@ -169,6 +218,53 @@ cmsINLINE cmsBool convert_utf16_to_utf32(cmsIOHANDLER* io, cmsInt32Number n, wch
             else
                 return FALSE;   // Corrupted string, just ignore
         }
+    }
+
+    return TRUE;
+}
+
+// Same decode as convert_utf16_to_utf32, but also records, for every on-disk UTF-16
+// code unit position consumed, the corresponding index into the decoded 'output' array
+// (UnitToOutputIndex must have room for nUnits + 1 elements). This lets a position table
+// expressed in on-disk UTF-16 unit offsets (as used by the MLU tag directory) be translated
+// into correct indices into 'output', even where a UTF-16 surrogate pair collapses two
+// on-disk units into a single decoded wchar_t (32-bit wchar_t platforms only; on platforms
+// where wchar_t already matches the on-disk unit size this is just the identity mapping).
+cmsINLINE cmsBool convert_utf16_to_utf32_indexed(cmsIOHANDLER* io, cmsUInt32Number nUnits, wchar_t* output, cmsUInt32Number* UnitToOutputIndex)
+{
+    cmsUInt32Number unitIdx = 0, outIdx = 0;
+
+    UnitToOutputIndex[0] = 0;
+
+    while (unitIdx < nUnits)
+    {
+        cmsUInt16Number uc;
+
+        if (!_cmsReadUInt16Number(io, &uc)) return FALSE;
+        unitIdx++;
+
+        if (!is_surrogate(uc))
+        {
+            output[outIdx++] = (wchar_t) uc;
+        }
+        else {
+
+            cmsUInt16Number low;
+
+            // A dangling high surrogate as the very last unit in budget has no room
+            // for its pair; bail out rather than reading past nUnits.
+            if (unitIdx >= nUnits) return FALSE;
+
+            if (!_cmsReadUInt16Number(io, &low)) return FALSE;
+            unitIdx++;
+
+            if (is_high_surrogate(uc) && is_low_surrogate(low))
+                output[outIdx++] = (wchar_t) surrogate_to_utf32(uc, low);
+            else
+                return FALSE;   // Corrupted string, just ignore
+        }
+
+        UnitToOutputIndex[unitIdx] = outIdx;
     }
 
     return TRUE;
@@ -1204,7 +1300,7 @@ cmsBool  Type_Text_Description_Write(struct _cms_typehandler_struct* self, cmsIO
     cmsMLU* mlu = (cmsMLU*) Ptr;
     char *Text = NULL;
     wchar_t *Wide = NULL;
-    cmsUInt32Number len, len_text, len_tag_requirement, len_aligned;
+    cmsUInt32Number len, len_text, ucCount, len_tag_requirement, len_aligned;
     cmsBool  rc = FALSE;
     char Filler[68];
 
@@ -1248,8 +1344,12 @@ cmsBool  Type_Text_Description_Write(struct _cms_typehandler_struct* self, cmsIO
 
     // Tell the real text len including the null terminator and padding
     len_text = (cmsUInt32Number) strlen(Text) + 1;
+    // Unicode representation may need more on-disk UTF-16 units than len_text wchar_t
+    // elements whenever a code point above 0xffff needs to be encoded as a UTF-16
+    // surrogate pair (only reachable on 32-bit wchar_t platforms).
+    ucCount = _cmsCountUtf16Units(Wide, len_text);
     // Compute an total tag size requirement
-    len_tag_requirement = (8+4+len_text+4+4+2*len_text+2+1+67);
+    len_tag_requirement = (8+4+len_text+4+4+2*ucCount+2+1+67);
     len_aligned = _cmsALIGNLONG(len_tag_requirement);
 
   // * cmsUInt32Number       count;          * Description length
@@ -1266,7 +1366,7 @@ cmsBool  Type_Text_Description_Write(struct _cms_typehandler_struct* self, cmsIO
 
     if (!_cmsWriteUInt32Number(io, 0)) goto Error;  // ucLanguageCode
 
-    if (!_cmsWriteUInt32Number(io, len_text)) goto Error;
+    if (!_cmsWriteUInt32Number(io, ucCount)) goto Error;
     // Note that in some compilers sizeof(cmsUInt16Number) != sizeof(wchar_t)
     if (!_cmsWriteWCharArray(io, len_text, Wide)) goto Error;
 
@@ -1686,6 +1786,9 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
     cmsUInt32Number  i;
     wchar_t*         Block;
     cmsUInt32Number  BeginOfThisString, EndOfThisString, LargestPosition;
+    cmsUInt32Number* RawBegin = NULL;   // Per-entry on-disk begin, in UTF-16 code units
+    cmsUInt32Number* RawLen = NULL;     // Per-entry on-disk length, in UTF-16 code units
+    cmsUInt32Number* UnitToWChar = NULL; // Maps an on-disk UTF-16 unit index to its decoded wchar_t index
 
     *nItems = 0;
     if (!_cmsReadUInt32Number(io, &Count)) return NULL;
@@ -1705,6 +1808,13 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
     SizeOfHeader = 12 * Count + sizeof(_cmsTagBase);
     LargestPosition = 0;
 
+    if (Count > 0) {
+
+        RawBegin = (cmsUInt32Number*) _cmsCalloc(self ->ContextID, Count, sizeof(cmsUInt32Number));
+        RawLen   = (cmsUInt32Number*) _cmsCalloc(self ->ContextID, Count, sizeof(cmsUInt32Number));
+        if (RawBegin == NULL || RawLen == NULL) goto Error;
+    }
+
     for (i=0; i < Count; i++) {
 
         if (!_cmsReadUInt16Number(io, &mlu ->Entries[i].Language)) goto Error;
@@ -1714,22 +1824,24 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
         if (!_cmsReadUInt32Number(io, &Len)) goto Error;
         if (!_cmsReadUInt32Number(io, &Offset)) goto Error;
 
-        // Offset MUST be even because it indexes a block of utf16 chars. 
+        // Offset MUST be even because it indexes a block of utf16 chars.
         // Tricky profiles that uses odd positions will not work anyway
-        // because the whole utf16 block is previously converted to wchar_t 
+        // because the whole utf16 block is previously converted to wchar_t
         // and sizeof this type may be of 4 bytes. On Linux systems, for example.
         if (Offset & 1) goto Error;
 
         // Check for overflow
-        if (Offset < (SizeOfHeader + 8)) goto Error;        
+        if (Offset < (SizeOfHeader + 8)) goto Error;
         if (((Offset + Len) < Len) || ((Offset + Len) > SizeOfTag + 8)) goto Error;
 
-        // True begin of the string
+        // True begin of the string, still in on-disk UTF-16 byte terms
         BeginOfThisString = Offset - SizeOfHeader - 8;
 
-        // Adjust to wchar_t elements
-        mlu ->Entries[i].Len = (Len * sizeof(wchar_t)) / sizeof(cmsUInt16Number);
-        mlu ->Entries[i].StrW = (BeginOfThisString * sizeof(wchar_t)) / sizeof(cmsUInt16Number);
+        // Final StrW/Len (in decoded wchar_t terms) are resolved below, once the pool has
+        // been decoded, since a UTF-16 surrogate pair collapses two on-disk code units into
+        // a single wchar_t on 32-bit wchar_t platforms and a fixed scale can't account for that.
+        RawBegin[i] = BeginOfThisString;
+        RawLen[i]   = Len;
 
         // To guess maximum size, add offset + len
         EndOfThisString = BeginOfThisString + Len;
@@ -1742,6 +1854,7 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
     if (SizeOfTag == 0)
     {
         Block = NULL;
+        NumOfWchar = 0;
     }
     else
     {
@@ -1750,22 +1863,74 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
 
         Block = (wchar_t*) _cmsCalloc(self ->ContextID, 1, SizeOfTag);
         if (Block == NULL) goto Error;
-       
+
         NumOfWchar = SizeOfTag / sizeof(wchar_t);
-        if (!_cmsReadWCharArray(io, NumOfWchar, Block)) {
+
+        // Sentinel-fill: convert_utf16_to_utf32_indexed only writes a unit index once
+        // the decoded element it belongs to is complete, so the unit index that falls
+        // strictly between the two halves of a surrogate pair is left untouched. Filling
+        // with an invalid marker up front (instead of calloc's 0) makes that gap
+        // distinguishable from a real, valid index 0 below.
+        UnitToWChar = (cmsUInt32Number*) _cmsMalloc(self ->ContextID, (NumOfWchar + 1) * sizeof(cmsUInt32Number));
+        if (UnitToWChar == NULL) {
             _cmsFree(self->ContextID, Block);
             goto Error;
         }
+        memset(UnitToWChar, 0xff, (NumOfWchar + 1) * sizeof(cmsUInt32Number));
+
+        if (!convert_utf16_to_utf32_indexed(io, NumOfWchar, Block, UnitToWChar)) {
+            _cmsFree(self->ContextID, Block);
+            goto Error;
+        }
+    }
+
+    // Translate each entry's on-disk position into indices into the decoded Block,
+    // via the unit->wchar map built above (BeginOfThisString/Len are byte offsets;
+    // sizeof(cmsUInt16Number) converts them to on-disk UTF-16 unit indices). A position
+    // that doesn't land on a valid decoded-character boundary (e.g. a crafted profile
+    // pointing an entry's offset into the middle of another entry's surrogate pair)
+    // reads back as the 0xff...ff sentinel and is rejected outright, rather than risking
+    // an unsigned underflow of Len if it were silently treated as index 0.
+    for (i=0; i < Count; i++) {
+
+        cmsUInt32Number BeginUnit = RawBegin[i] / sizeof(cmsUInt16Number);
+        cmsUInt32Number EndUnit   = (RawBegin[i] + RawLen[i]) / sizeof(cmsUInt16Number);
+        cmsUInt32Number StrWIndex, EndIndex;
+
+        if (UnitToWChar == NULL) {
+
+            // Empty pool: only zero-length entries are valid.
+            if (RawLen[i] != 0) goto Error;
+            mlu ->Entries[i].StrW = 0;
+            mlu ->Entries[i].Len  = 0;
+            continue;
+        }
+
+        StrWIndex = UnitToWChar[BeginUnit];
+        EndIndex  = UnitToWChar[EndUnit];
+
+        if (StrWIndex == 0xffffffffu || EndIndex == 0xffffffffu || EndIndex < StrWIndex)
+            goto Error;
+
+        mlu ->Entries[i].StrW = StrWIndex * sizeof(wchar_t);
+        mlu ->Entries[i].Len  = (EndIndex - StrWIndex) * sizeof(wchar_t);
     }
 
     mlu ->MemPool  = Block;
     mlu ->PoolSize = SizeOfTag;
     mlu ->PoolUsed = SizeOfTag;
 
+    if (RawBegin) _cmsFree(self ->ContextID, RawBegin);
+    if (RawLen) _cmsFree(self ->ContextID, RawLen);
+    if (UnitToWChar) _cmsFree(self ->ContextID, UnitToWChar);
+
     *nItems = 1;
     return (void*) mlu;
 
 Error:
+    if (RawBegin) _cmsFree(self ->ContextID, RawBegin);
+    if (RawLen) _cmsFree(self ->ContextID, RawLen);
+    if (UnitToWChar) _cmsFree(self ->ContextID, UnitToWChar);
     if (mlu) cmsMLUfree(mlu);
     return NULL;
 }
@@ -1775,8 +1940,9 @@ cmsBool  Type_MLU_Write(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, 
 {
     cmsMLU* mlu =(cmsMLU*) Ptr;
     cmsUInt32Number HeaderSize;
-    cmsUInt32Number  Len, Offset;
+    cmsUInt32Number  Len, Offset, DiskOffset;
     cmsUInt32Number i;
+    const cmsUInt8Number* Pool;
 
     if (Ptr == NULL) {
 
@@ -1790,19 +1956,27 @@ cmsBool  Type_MLU_Write(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, 
     if (!_cmsWriteUInt32Number(io, 12)) return FALSE;
 
     HeaderSize = 12 * mlu ->UsedEntries + sizeof(_cmsTagBase);
+    Pool = (const cmsUInt8Number*) mlu ->MemPool;
+    DiskOffset = 0;
 
+    // Entries are appended to the pool in order, so StrW is monotonically
+    // increasing with i and each entry's on-disk slice can be measured in turn.
     for (i=0; i < mlu ->UsedEntries; i++) {
 
-        Len    =  mlu ->Entries[i].Len;
-        Offset =  mlu ->Entries[i].StrW;
+        const wchar_t* StrW = (const wchar_t*) (Pool + mlu ->Entries[i].StrW);
+        cmsUInt32Number LenInWChars = mlu ->Entries[i].Len / sizeof(wchar_t);
 
-        Len    = (Len * sizeof(cmsUInt16Number)) / sizeof(wchar_t);
-        Offset = (Offset * sizeof(cmsUInt16Number)) / sizeof(wchar_t) + HeaderSize + 8;
+        // On-disk length may exceed the in-memory wchar_t count whenever this
+        // string holds code points above 0xffff, encoded as UTF-16 surrogate pairs.
+        Len    = _cmsCountUtf16Units(StrW, LenInWChars) * sizeof(cmsUInt16Number);
+        Offset = DiskOffset + HeaderSize + 8;
 
         if (!_cmsWriteUInt16Number(io, mlu ->Entries[i].Language)) return FALSE;
         if (!_cmsWriteUInt16Number(io, mlu ->Entries[i].Country))  return FALSE;
         if (!_cmsWriteUInt32Number(io, Len)) return FALSE;
         if (!_cmsWriteUInt32Number(io, Offset)) return FALSE;
+
+        DiskOffset += Len;
     }
 
     if (!_cmsWriteWCharArray(io, mlu ->PoolUsed / sizeof(wchar_t), (wchar_t*)  mlu ->MemPool)) return FALSE;

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -1936,9 +1936,11 @@ cmsBool  Type_MLU_Write(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, 
 {
     cmsMLU* mlu =(cmsMLU*) Ptr;
     cmsUInt32Number HeaderSize;
-    cmsUInt32Number  Len, Offset, DiskOffset;
+    cmsUInt32Number  Len, Offset;
     cmsUInt32Number i;
-    const cmsUInt8Number* Pool;
+    cmsUInt32Number  PoolWChars;
+    cmsUInt32Number* WCharToUnit = NULL;
+    cmsBool rc = FALSE;
 
     if (Ptr == NULL) {
 
@@ -1952,32 +1954,59 @@ cmsBool  Type_MLU_Write(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, 
     if (!_cmsWriteUInt32Number(io, 12)) return FALSE;
 
     HeaderSize = 12 * mlu ->UsedEntries + sizeof(_cmsTagBase);
-    Pool = (const cmsUInt8Number*) mlu ->MemPool;
-    DiskOffset = 0;
+    PoolWChars = mlu ->PoolUsed / sizeof(wchar_t);
 
-    // Entries are appended to the pool in order, so StrW is monotonically
-    // increasing with i and each entry's on-disk slice can be measured in turn.
-    for (i=0; i < mlu ->UsedEntries; i++) {
+    // Map every decoded wchar_t position in the shared pool to the on-disk UTF-16 unit
+    // offset it will be written at (mirroring, in reverse, the map Type_MLU_Read builds).
+    // Entries are NOT guaranteed to occupy distinct, sequentially increasing pool ranges:
+    // some encoders legitimately point two entries at the same StrW to share identical
+    // string data, a pattern this has to preserve rather than assume away. Since the map
+    // is purely a function of pool position, two entries with the same StrW naturally end
+    // up with the same on-disk Offset, exactly like the original fixed-scale code did
+    // before code points above 0xffff needed variable-width on-disk encoding.
+    if (PoolWChars > 0) {
 
-        const wchar_t* StrW = (const wchar_t*) (Pool + mlu ->Entries[i].StrW);
-        cmsUInt32Number LenInWChars = mlu ->Entries[i].Len / sizeof(wchar_t);
+        const wchar_t* WPool = (const wchar_t*) mlu ->MemPool;
+        cmsUInt32Number k, Units;
 
-        // On-disk length may exceed the in-memory wchar_t count whenever this
-        // string holds code points above 0xffff, encoded as UTF-16 surrogate pairs.
-        Len    = _cmsCountUtf16Units(StrW, LenInWChars) * sizeof(cmsUInt16Number);
-        Offset = DiskOffset + HeaderSize + 8;
+        WCharToUnit = (cmsUInt32Number*) _cmsMalloc(self ->ContextID, (PoolWChars + 1) * sizeof(cmsUInt32Number));
+        if (WCharToUnit == NULL) return FALSE;
 
-        if (!_cmsWriteUInt16Number(io, mlu ->Entries[i].Language)) return FALSE;
-        if (!_cmsWriteUInt16Number(io, mlu ->Entries[i].Country))  return FALSE;
-        if (!_cmsWriteUInt32Number(io, Len)) return FALSE;
-        if (!_cmsWriteUInt32Number(io, Offset)) return FALSE;
-
-        DiskOffset += Len;
+        for (k = 0, Units = 0; k < PoolWChars; k++) {
+            WCharToUnit[k] = Units;
+            Units += ((cmsUInt32Number) WPool[k] > 0xffff) ? 2 : 1;
+        }
+        WCharToUnit[PoolWChars] = Units;
     }
 
-    if (!_cmsWriteWCharArray(io, mlu ->PoolUsed / sizeof(wchar_t), (wchar_t*)  mlu ->MemPool)) return FALSE;
+    for (i=0; i < mlu ->UsedEntries; i++) {
 
-    return TRUE;
+        cmsUInt32Number StrWChar = mlu ->Entries[i].StrW / sizeof(wchar_t);
+        cmsUInt32Number EndWChar = StrWChar + (mlu ->Entries[i].Len / sizeof(wchar_t));
+
+        if (WCharToUnit == NULL) {
+            // No pool at all; only reachable if every entry is zero-length.
+            Len = 0;
+            Offset = HeaderSize + 8;
+        }
+        else {
+            Len    = (WCharToUnit[EndWChar] - WCharToUnit[StrWChar]) * sizeof(cmsUInt16Number);
+            Offset = WCharToUnit[StrWChar] * sizeof(cmsUInt16Number) + HeaderSize + 8;
+        }
+
+        if (!_cmsWriteUInt16Number(io, mlu ->Entries[i].Language)) goto Error;
+        if (!_cmsWriteUInt16Number(io, mlu ->Entries[i].Country))  goto Error;
+        if (!_cmsWriteUInt32Number(io, Len)) goto Error;
+        if (!_cmsWriteUInt32Number(io, Offset)) goto Error;
+    }
+
+    if (!_cmsWriteWCharArray(io, PoolWChars, (wchar_t*) mlu ->MemPool)) goto Error;
+
+    rc = TRUE;
+
+Error:
+    if (WCharToUnit) _cmsFree(self ->ContextID, WCharToUnit);
+    return rc;
 
     cmsUNUSED_PARAMETER(nItems);
     cmsUNUSED_PARAMETER(self);

--- a/src/cmstypes.c
+++ b/src/cmstypes.c
@@ -1811,7 +1811,9 @@ static
 void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsUInt32Number* nItems, cmsUInt32Number SizeOfTag)
 {
     cmsMLU* mlu;
-    cmsUInt32Number Count, RecLen, NumOfWchar;
+    cmsUInt32Number Count, RecLen;
+    cmsUInt32Number PoolBytes;          // Byte size of the decoded (wchar_t) pool allocation
+    cmsUInt32Number PoolUnits;          // Count of on-disk UTF-16 code units in the pool
     cmsUInt32Number SizeOfHeader;
     cmsUInt32Number  Len, Offset;
     cmsUInt32Number  i;
@@ -1880,34 +1882,39 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
             LargestPosition = EndOfThisString;
     }
 
-    // Now read the remaining of tag and fill all strings. Subtract the directory
-    SizeOfTag   = (LargestPosition * sizeof(wchar_t)) / sizeof(cmsUInt16Number);
-    if (SizeOfTag == 0)
+    // Now read the remaining of tag and fill all strings. Subtract the directory.
+    // LargestPosition is in on-disk bytes; each 2-byte on-disk UTF-16 unit decodes to
+    // at most one wchar_t, so scaling by sizeof(wchar_t)/sizeof(cmsUInt16Number) gives
+    // an allocation size that always fits the decoded pool.
+    PoolBytes = (LargestPosition * sizeof(wchar_t)) / sizeof(cmsUInt16Number);
+    if (PoolBytes == 0)
     {
         Block = NULL;
-        NumOfWchar = 0;
+        PoolUnits = 0;
     }
     else
     {
         // Make sure this is an even utf16 size.
-        if (SizeOfTag & 1) goto Error;
+        if (PoolBytes & 1) goto Error;
 
-        Block = (wchar_t*) _cmsCalloc(self ->ContextID, 1, SizeOfTag);
+        Block = (wchar_t*) _cmsCalloc(self ->ContextID, 1, PoolBytes);
         if (Block == NULL) goto Error;
 
-        NumOfWchar = SizeOfTag / sizeof(wchar_t);
+        // The sizeof(wchar_t) factors cancel: this is LargestPosition / sizeof(cmsUInt16Number),
+        // i.e. exactly the number of 2-byte UTF-16 code units the pool occupies on disk.
+        PoolUnits = PoolBytes / sizeof(wchar_t);
 
         // Sentinel-fill: convert_utf16_to_utf32_indexed only writes a unit index once
         // the decoded element it belongs to is complete, so the unit index that falls
         // strictly between the two halves of a surrogate pair is left untouched. Filling
         // with an invalid marker up front (instead of calloc's 0) makes that gap
         // distinguishable from a real, valid index 0 below.
-        UnitToWChar = (cmsUInt32Number*) _cmsMalloc(self ->ContextID, (NumOfWchar + 1) * sizeof(cmsUInt32Number));
+        UnitToWChar = (cmsUInt32Number*) _cmsMalloc(self ->ContextID, (PoolUnits + 1) * sizeof(cmsUInt32Number));
         if (UnitToWChar == NULL) goto Error;
 
-        memset(UnitToWChar, 0xff, (NumOfWchar + 1) * sizeof(cmsUInt32Number));
+        memset(UnitToWChar, 0xff, (PoolUnits + 1) * sizeof(cmsUInt32Number));
 
-        if (!convert_utf16_to_utf32_indexed(io, NumOfWchar, Block, UnitToWChar)) goto Error;
+        if (!convert_utf16_to_utf32_indexed(io, PoolUnits, Block, UnitToWChar)) goto Error;
     }
 
     // Translate each entry's on-disk position into indices into the decoded Block,
@@ -1943,8 +1950,8 @@ void *Type_MLU_Read(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, cmsU
     }
 
     mlu ->MemPool  = Block;
-    mlu ->PoolSize = SizeOfTag;
-    mlu ->PoolUsed = SizeOfTag;
+    mlu ->PoolSize = PoolBytes;
+    mlu ->PoolUsed = PoolBytes;
 
     if (RawBegin) _cmsFree(self ->ContextID, RawBegin);
     if (RawLen) _cmsFree(self ->ContextID, RawLen);
@@ -2021,6 +2028,14 @@ cmsBool  Type_MLU_Write(struct _cms_typehandler_struct* self, cmsIOHANDLER* io, 
 
         cmsUInt32Number StrWChar = mlu ->Entries[i].StrW / sizeof(wchar_t);
         cmsUInt32Number EndWChar = StrWChar + (mlu ->Entries[i].Len / sizeof(wchar_t));
+
+        // Defensive: the MLU being written is an in-memory object that need not have
+        // come from Type_MLU_Read, so its per-entry StrW/Len cannot be trusted to
+        // describe a valid range inside the pool. Reject any entry that would index
+        // the position map out of bounds (or whose end wrapped around below its start)
+        // instead of over-reading WCharToUnit.
+        if (StrWChar > PoolWChars || EndWChar > PoolWChars || EndWChar < StrWChar)
+            goto Error;
 
         if (WCharToUnit == NULL) {
             // No pool at all; only reachable if every entry is zero-length.

--- a/testbed/testcms2.c
+++ b/testbed/testcms2.c
@@ -3857,6 +3857,86 @@ Error:
 }
 
 
+// Regression test for an interop bug found by review: two mluc entries can
+// legitimately share the same on-disk position (some encoders dedup repeated
+// string data this way), which Type_MLU_Write must preserve rather than assume
+// every entry occupies a distinct, sequentially increasing pool range.
+static
+cmsInt32Number CheckMLU_SharedEntryRoundtrip(void)
+{
+    // A hand-built 'mluc' tag: 2 entries ("en/US", "fr/FR") both pointing at the
+    // exact same on-disk position/length -- one shared copy of the string "AB".
+    static const cmsUInt8Number RawTag[] = {
+        'm','l','u','c',               // type signature
+        0,0,0,0,                       // reserved
+        0,0,0,2,                       // Count = 2
+        0,0,0,12,                      // RecLen = 12
+        'e','n','U','S', 0,0,0,4, 0,0,0,40,   // entry 0: Len=4, Offset=40 (shared)
+        'f','r','F','R', 0,0,0,4, 0,0,0,40,   // entry 1: Len=4, Offset=40 (same as entry 0)
+        0,'A', 0,'B'                    // pool: "AB", one copy only
+    };
+    cmsHPROFILE h1 = NULL, h2 = NULL;
+    cmsMLU* mlu1;
+    cmsMLU* mlu2;
+    cmsUInt32Number clen;
+    void* data = NULL;
+    char Buffer[8];
+    cmsInt32Number rc = 1;
+
+    h1 = cmsCreate_sRGBProfile();
+    cmsWriteRawTag(h1, cmsSigProfileDescriptionTag, RawTag, sizeof(RawTag));
+
+    if (!cmsSaveProfileToMem(h1, NULL, &clen)) { rc = 0; goto Error; }
+    data = malloc(clen);
+    if (data == NULL) { rc = 0; goto Error; }
+    if (!cmsSaveProfileToMem(h1, data, &clen)) { rc = 0; goto Error; }
+    cmsCloseProfile(h1);
+
+    h1 = cmsOpenProfileFromMemTHR(DbgThread(), data, clen);
+    free(data); data = NULL;
+    if (h1 == NULL) { Fail("shared-entry mluc: profile didn't reopen"); rc = 0; goto Error; }
+
+    mlu1 = (cmsMLU*) cmsReadTag(h1, cmsSigProfileDescriptionTag);
+    if (mlu1 == NULL) { Fail("shared-entry mluc: profile didn't get the MLU back"); rc = 0; goto Error; }
+
+    cmsMLUgetASCII(mlu1, "en", "US", Buffer, sizeof(Buffer));
+    if (strcmp(Buffer, "AB") != 0) { Fail("shared-entry mluc: 'en' entry wrong before re-write"); rc = 0; }
+
+    cmsMLUgetASCII(mlu1, "fr", "FR", Buffer, sizeof(Buffer));
+    if (strcmp(Buffer, "AB") != 0) { Fail("shared-entry mluc: 'fr' entry wrong before re-write"); rc = 0; }
+
+    if (rc == 0) goto Error;
+
+    // The actual regression: re-serialize this MLU through the normal write path
+    // (not hand-built bytes) and read it back. A write side that assumes entries
+    // never share a position desyncs the second entry's offset from what's
+    // actually written, corrupting or losing that entry on the round trip.
+    h2 = cmsOpenProfileFromFileTHR(DbgThread(), "mlushared.icc", "w");
+    cmsSetProfileVersion(h2, 4.3);
+    cmsWriteTag(h2, cmsSigProfileDescriptionTag, mlu1);
+    cmsCloseProfile(h2); h2 = NULL;
+    cmsCloseProfile(h1); h1 = NULL;
+
+    h2 = cmsOpenProfileFromFileTHR(DbgThread(), "mlushared.icc", "r");
+    mlu2 = (cmsMLU*) cmsReadTag(h2, cmsSigProfileDescriptionTag);
+    if (mlu2 == NULL) { Fail("shared-entry mluc: re-written profile didn't get the MLU back"); rc = 0; goto Error; }
+
+    cmsMLUgetASCII(mlu2, "en", "US", Buffer, sizeof(Buffer));
+    if (strcmp(Buffer, "AB") != 0) { Fail("shared-entry mluc: 'en' entry corrupted after re-write"); rc = 0; }
+
+    cmsMLUgetASCII(mlu2, "fr", "FR", Buffer, sizeof(Buffer));
+    if (strcmp(Buffer, "AB") != 0) { Fail("shared-entry mluc: 'fr' entry corrupted after re-write"); rc = 0; }
+
+Error:
+    if (h1 != NULL) cmsCloseProfile(h1);
+    if (h2 != NULL) cmsCloseProfile(h2);
+    if (data != NULL) free(data);
+    remove("mlushared.icc");
+
+    return rc;
+}
+
+
 
 // A lightweight test of named color structures.
 static
@@ -9952,6 +10032,7 @@ int main(int argc, char* argv[])
     Check("Multilocalized Unicode (II)", CheckMLU_UTF8);
     Check("Multilocalized Unicode Supplementary Plane", CheckMLU_SupplementaryPlane);
     Check("Multilocalized Unicode Malformed Surrogate Offset", CheckMLU_MalformedSurrogateOffset);
+    Check("Multilocalized Unicode Shared Entry Roundtrip", CheckMLU_SharedEntryRoundtrip);
 
     // Named color
     Check("Named color lists", CheckNamedColorList);

--- a/testbed/testcms2.c
+++ b/testbed/testcms2.c
@@ -3937,6 +3937,110 @@ Error:
 }
 
 
+// Boundary and invalid wchar_t scalar values on the write path: the largest BMP
+// value (U+FFFF), the first and last supplementary-plane values (U+10000,
+// U+10FFFF) must all round-trip correctly, while a value that isn't a valid
+// Unicode scalar at all -- a lone UTF-16 surrogate code point (U+D800), or
+// anything above the maximum scalar value U+10FFFF -- must make the write fail
+// cleanly instead of emitting structurally invalid UTF-16.
+static
+cmsInt32Number CheckMLU_ScalarValidation(void)
+{
+    static const cmsUInt32Number Valid[]   = { 0xffff, 0x10000, 0x10ffff };
+    static const cmsUInt32Number Invalid[] = { 0xd800, 0x110000 };
+
+    cmsHPROFILE h = NULL;
+    cmsMLU* mlu = NULL;
+    wchar_t Str[2];
+    cmsUInt32Number vi, clen;
+    cmsInt32Number rc = 1;
+
+    if (sizeof(wchar_t) < 4) return 1;
+
+    cmsSetLogErrorHandler(NULL);
+
+    for (vi = 0; vi < 3; vi++) {
+
+        wchar_t Buffer[4];
+
+        Str[0] = (wchar_t) Valid[vi];
+        Str[1] = 0;
+
+        mlu = cmsMLUalloc(DbgThread(), 0);
+        cmsMLUsetWide(mlu, "en", "US", Str);
+
+        h = cmsOpenProfileFromFileTHR(DbgThread(), "mluvalidscalar.icc", "w");
+        cmsSetProfileVersion(h, 4.3);
+        cmsWriteTag(h, cmsSigProfileDescriptionTag, mlu);
+        cmsCloseProfile(h); h = NULL;
+        cmsMLUfree(mlu); mlu = NULL;
+
+        h = cmsOpenProfileFromFileTHR(DbgThread(), "mluvalidscalar.icc", "r");
+        mlu = (cmsMLU*) cmsReadTag(h, cmsSigProfileDescriptionTag);
+        if (mlu == NULL) { Fail("scalar validation: valid boundary scalar 0x%x rejected", Valid[vi]); rc = 0; }
+        else {
+            cmsMLUgetWide(mlu, "en", "US", Buffer, sizeof(Buffer));
+            if (memcmp(Buffer, Str, sizeof(Str)) != 0) { Fail("scalar validation: valid boundary scalar 0x%x corrupted", Valid[vi]); rc = 0; }
+        }
+        cmsCloseProfile(h); h = NULL;
+        mlu = NULL; // owned by the now-closed profile
+        remove("mluvalidscalar.icc");
+
+        if (rc == 0) goto Error;
+    }
+
+    // mluc (v4) path: Type_MLU_Write's pool scan must reject these before writing.
+    for (vi = 0; vi < 2; vi++) {
+
+        Str[0] = (wchar_t) Invalid[vi];
+        Str[1] = 0;
+
+        mlu = cmsMLUalloc(DbgThread(), 0);
+        cmsMLUsetWide(mlu, "en", "US", Str);
+
+        h = cmsCreate_sRGBProfile();
+        cmsSetProfileVersion(h, 4.3);
+        cmsWriteTag(h, cmsSigProfileDescriptionTag, mlu);
+        cmsMLUfree(mlu); mlu = NULL;
+
+        if (cmsSaveProfileToMem(h, NULL, &clen)) { Fail("scalar validation: invalid mluc scalar 0x%x was accepted", Invalid[vi]); rc = 0; }
+
+        cmsCloseProfile(h); h = NULL;
+
+        if (rc == 0) goto Error;
+    }
+
+    // desc (v2) path: Type_Text_Description_Write must reject these too.
+    for (vi = 0; vi < 2; vi++) {
+
+        Str[0] = (wchar_t) Invalid[vi];
+        Str[1] = 0;
+
+        mlu = cmsMLUalloc(DbgThread(), 0);
+        cmsMLUsetWide(mlu, "en", "US", Str);
+
+        h = cmsCreate_sRGBProfile();
+        cmsSetProfileVersion(h, 2.1);
+        cmsWriteTag(h, cmsSigProfileDescriptionTag, mlu);
+        cmsMLUfree(mlu); mlu = NULL;
+
+        if (cmsSaveProfileToMem(h, NULL, &clen)) { Fail("scalar validation: invalid desc scalar 0x%x was accepted", Invalid[vi]); rc = 0; }
+
+        cmsCloseProfile(h); h = NULL;
+
+        if (rc == 0) goto Error;
+    }
+
+Error:
+    if (h != NULL) cmsCloseProfile(h);
+    if (mlu != NULL) cmsMLUfree(mlu);
+    remove("mluvalidscalar.icc");
+    ResetFatalError();
+
+    return rc;
+}
+
+
 
 // A lightweight test of named color structures.
 static
@@ -10033,6 +10137,7 @@ int main(int argc, char* argv[])
     Check("Multilocalized Unicode Supplementary Plane", CheckMLU_SupplementaryPlane);
     Check("Multilocalized Unicode Malformed Surrogate Offset", CheckMLU_MalformedSurrogateOffset);
     Check("Multilocalized Unicode Shared Entry Roundtrip", CheckMLU_SharedEntryRoundtrip);
+    Check("Multilocalized Unicode Scalar Validation", CheckMLU_ScalarValidation);
 
     // Named color
     Check("Named color lists", CheckNamedColorList);

--- a/testbed/testcms2.c
+++ b/testbed/testcms2.c
@@ -3699,6 +3699,164 @@ cmsInt32Number CheckMLU_UTF8(void)
 }
 
 
+// Check that code points above U+FFFF (which require a UTF-16 surrogate pair on disk)
+// round-trip correctly through both the legacy 'desc' tag (ICC < v4) and the modern
+// 'mluc' tag (ICC >= v4). On platforms where wchar_t is 32 bits (Linux/macOS) each such
+// code point is stored as a single wchar_t internally, but the on-disk encoding is
+// always UTF-16, so the write side has to expand it into a surrogate pair and the read
+// side (together with the mluc position table) has to account for that expansion.
+// See Little-CMS issue #180.
+static
+cmsInt32Number CheckMLU_SupplementaryPlane(void)
+{
+    cmsHPROFILE h = NULL;
+    cmsMLU *mlu = NULL, *mlu2, *mlu3;
+    wchar_t Emoji[2];
+    wchar_t Buffer[256];
+    cmsInt32Number rc = 1;
+
+    // Nothing extra to exercise on platforms where wchar_t itself is only 16 bits:
+    // there the caller already has to pre-encode supplementary-plane text as a
+    // surrogate pair, so _cmsWriteWCharArray/_cmsReadWCharArray never see a raw
+    // code point above 0xffff in the first place.
+    if (sizeof(wchar_t) < 4) return 1;
+
+    Emoji[0] = (wchar_t) 0x1F600;  // U+1F600 GRINNING FACE
+    Emoji[1] = 0;
+
+    // --- mluc tag (ICC v4): several entries sharing one on-disk pool. The
+    // supplementary-plane entry sits in the middle so that the later "fr"/"FR" entry
+    // only reads back correctly if both the write-side position table and the
+    // read-side decode-offset math correctly account for the extra on-disk UTF-16
+    // unit the surrogate pair needs.
+    mlu = cmsMLUalloc(DbgThread(), 0);
+    cmsMLUsetWide(mlu, "en", "US", L"Hello, world");
+    cmsMLUsetWide(mlu, "ja", "JP", Emoji);
+    cmsMLUsetWide(mlu, "fr", "FR", L"Bonjour, le monde");
+
+    h = cmsOpenProfileFromFileTHR(DbgThread(), "mlusurrogate.icc", "w");
+    cmsSetProfileVersion(h, 4.3);
+    cmsWriteTag(h, cmsSigProfileDescriptionTag, mlu);
+    cmsCloseProfile(h);
+    cmsMLUfree(mlu); mlu = NULL;
+
+    h = cmsOpenProfileFromFileTHR(DbgThread(), "mlusurrogate.icc", "r");
+    // mlu2 is owned by the profile (cmsReadTag caches it internally); it must NOT be
+    // freed separately, only via the cmsCloseProfile(h) below.
+    mlu2 = (cmsMLU*) cmsReadTag(h, cmsSigProfileDescriptionTag);
+    if (mlu2 == NULL) { Fail("mluc: profile didn't get the MLU back"); rc = 0; goto Error; }
+
+    cmsMLUgetWide(mlu2, "en", "US", Buffer, sizeof(Buffer));
+    if (memcmp(Buffer, L"Hello, world", sizeof(L"Hello, world")) != 0) { Fail("mluc: 'en' entry corrupted"); rc = 0; }
+
+    cmsMLUgetWide(mlu2, "ja", "JP", Buffer, sizeof(Buffer));
+    if (memcmp(Buffer, Emoji, sizeof(Emoji)) != 0) { Fail("mluc: supplementary-plane entry corrupted"); rc = 0; }
+
+    // This is the entry that actually exercises the position-table fix: a broken
+    // offset here would decode garbage or truncated content, not crash.
+    cmsMLUgetWide(mlu2, "fr", "FR", Buffer, sizeof(Buffer));
+    if (memcmp(Buffer, L"Bonjour, le monde", sizeof(L"Bonjour, le monde")) != 0) { Fail("mluc: entry after supplementary-plane entry corrupted"); rc = 0; }
+
+    cmsCloseProfile(h); h = NULL;
+    remove("mlusurrogate.icc");
+
+    if (rc == 0) goto Error;
+
+    // --- desc tag (legacy, ICC v2): single entry, exercises the ucCount/size fix.
+    mlu = cmsMLUalloc(DbgThread(), 0);
+    cmsMLUsetWide(mlu, "en", "US", Emoji);
+
+    h = cmsOpenProfileFromFileTHR(DbgThread(), "descsurrogate.icc", "w");
+    cmsSetProfileVersion(h, 2.1);
+    cmsWriteTag(h, cmsSigProfileDescriptionTag, mlu);
+    cmsCloseProfile(h);
+    cmsMLUfree(mlu); mlu = NULL;
+
+    h = cmsOpenProfileFromFileTHR(DbgThread(), "descsurrogate.icc", "r");
+    // mlu3, likewise, is owned by the profile.
+    mlu3 = (cmsMLU*) cmsReadTag(h, cmsSigProfileDescriptionTag);
+    if (mlu3 == NULL) { Fail("desc: profile didn't get the MLU back"); rc = 0; goto Error; }
+
+    cmsMLUgetWide(mlu3, cmsV2Unicode, cmsV2Unicode, Buffer, sizeof(Buffer));
+    if (memcmp(Buffer, Emoji, sizeof(Emoji)) != 0) { Fail("desc: supplementary-plane entry corrupted"); rc = 0; }
+
+Error:
+    if (h != NULL) cmsCloseProfile(h);
+    if (mlu != NULL) cmsMLUfree(mlu);
+    remove("mlusurrogate.icc");
+    remove("descsurrogate.icc");
+
+    return rc;
+}
+
+
+// Regression test for a crafted mluc tag whose second entry's on-disk offset points
+// squarely between the two halves of the first entry's UTF-16 surrogate pair (a
+// position no well-formed writer would ever produce, but a hostile one could). Reading
+// this must fail cleanly rather than compute an out-of-range entry length: earlier,
+// before the read side tracked which on-disk positions are valid decoded-character
+// boundaries, this triggered an unsigned-integer underflow of the entry's Len (End
+// index < Start index), leading to a huge bogus length and a heap over-read in
+// cmsMLUgetWide/getASCII/getUTF8.
+static
+cmsInt32Number CheckMLU_MalformedSurrogateOffset(void)
+{
+    // A hand-built 'mluc' tag: 2 entries, pool = two valid UTF-16 surrogate pairs
+    // for U+1F600 (D8 3D DE 00) back to back. Entry 0 spans the whole pool (benign).
+    // Entry 1's on-disk range is units [2,3) -- starting exactly at the second pair's
+    // high surrogate, but ending one unit later, squarely between that pair's two
+    // halves, a position convert_utf16_to_utf32_indexed never assigns a decoded index to.
+    static const cmsUInt8Number RawTag[] = {
+        'm','l','u','c',               // type signature
+        0,0,0,0,                       // reserved
+        0,0,0,2,                       // Count = 2
+        0,0,0,12,                      // RecLen = 12
+        'e','n','U','S', 0,0,0,8,  0,0,0,40,   // entry 0: Len=8, Offset=40
+        'j','a','J','P', 0,0,0,2,  0,0,0,44,   // entry 1: Len=2, Offset=44 (malicious)
+        0xD8,0x3D, 0xDE,0x00, 0xD8,0x3D, 0xDE,0x00  // pool: two surrogate pairs
+    };
+    cmsHPROFILE h;
+    cmsMLU* mlu;
+    cmsUInt32Number clen;
+    void* data;
+    cmsInt32Number rc = 1;
+
+    if (sizeof(wchar_t) < 4) return 1;
+
+    h = cmsCreate_sRGBProfile();
+    cmsSetLogErrorHandler(NULL);
+
+    cmsWriteRawTag(h, cmsSigProfileDescriptionTag, RawTag, sizeof(RawTag));
+
+    if (!cmsSaveProfileToMem(h, NULL, &clen)) { rc = 0; goto Error; }
+    data = malloc(clen);
+    if (data == NULL) { rc = 0; goto Error; }
+    if (!cmsSaveProfileToMem(h, data, &clen)) { free(data); rc = 0; goto Error; }
+    cmsCloseProfile(h);
+
+    h = cmsOpenProfileFromMemTHR(DbgThread(), data, clen);
+    free(data);
+    if (h == NULL) goto Error;  // Whole profile rejected outright is fine too.
+
+    // The point of this test: this must NOT crash / over-read, and must NOT
+    // report success with a garbage length. Either a clean rejection (NULL) or,
+    // if some other constraint made this pass, valid Entries are both acceptable;
+    // what would indicate the bug is back is a crash (caught by running under
+    // ASan/valgrind) or a wildly-out-of-range reported length.
+    mlu = (cmsMLU*) cmsReadTag(h, cmsSigProfileDescriptionTag);
+    if (mlu != NULL) {
+
+        cmsUInt32Number Needed = cmsMLUgetWide(mlu, "ja", "JP", NULL, 0);
+        if (Needed > sizeof(RawTag)) { Fail("Malformed mluc: bogus oversized length not rejected"); rc = 0; }
+    }
+
+Error:
+    if (h != NULL) cmsCloseProfile(h);
+    ResetFatalError();
+    return rc;
+}
+
+
 
 // A lightweight test of named color structures.
 static
@@ -9792,6 +9950,8 @@ int main(int argc, char* argv[])
     // MLU
     Check("Multilocalized Unicode", CheckMLU);
     Check("Multilocalized Unicode (II)", CheckMLU_UTF8);
+    Check("Multilocalized Unicode Supplementary Plane", CheckMLU_SupplementaryPlane);
+    Check("Multilocalized Unicode Malformed Surrogate Offset", CheckMLU_MalformedSurrogateOffset);
 
     // Named color
     Check("Named color lists", CheckNamedColorList);


### PR DESCRIPTION
Fixes #180.

## The problem

Little-CMS stores ICC profile description/copyright strings (`desc` and
`mluc` tags) internally as `wchar_t` arrays, one Unicode code point per
element. On platforms where `wchar_t` is 32 bits (Linux/macOS), any code
point fits in a single `wchar_t`, including supplementary-plane characters
above U+FFFF.

The on-disk ICC format for these tags is always UTF-16, where a code point
above U+FFFF has to be split into a two-unit surrogate pair. The read side
already handles this correctly (2.13 added `convert_utf16_to_utf32`), but as
@mm2 noted in the issue, the write side never did — `_cmsWriteWCharArray`
just truncated every value to 16 bits:

```c
// before
for (i=0; i < n; i++) {
    if (!_cmsWriteUInt16Number(io, (cmsUInt16Number) Array[i])) return FALSE;
}
```

Concretely, U+1F600 (😀) should serialize as the two-unit surrogate pair
`D8 3D DE 00`; before this fix it serialized as the single (wrong, and
mangled by the truncation) unit `E6 00`.

## Why this touches more than `_cmsWriteWCharArray`

Fixing just that loop isn't safe by itself: encoding a surrogate pair means
writing *more* on-disk bytes than the `wchar_t` count would predict, and two
tag writers precompute exact sizes/offsets from that count before writing
any data:

- `Type_Text_Description_Write` (legacy `desc` tag) declared the on-disk
  Unicode length field as exactly the ASCII length, and sized the whole tag
  from that same value.
- `Type_MLU_Write` (modern `mluc` tag) computed each entry's on-disk
  `Len`/`Offset` position-table fields via a fixed 1:1 scale between
  `wchar_t` count and on-disk units.

Both needed to account for the possible extra unit per surrogate pair, or a
surrogate pair anywhere in the string would desync the tag's declared size
or a later entry's offset from what's actually written, corrupting the tag.

While fixing `Type_MLU_Write`'s position table, I found an independent,
pre-existing bug on the *read* side (`Type_MLU_Read`): it converts on-disk
byte offsets into decoded-buffer offsets via the same kind of fixed 1:1
scale, computed *before* decoding — wrong whenever an earlier entry (in
on-disk order) contains a surrogate pair, since two on-disk units collapse
into one decoded `wchar_t`. A correct write side would be useless if nothing
it wrote could be read back correctly, so this needed fixing too.

## Summary of changes (`src/cmstypes.c`)

- `convert_utf32_to_utf16` (new): write-side mirror of the existing
  `convert_utf16_to_utf32`, encoding code points above U+FFFF as UTF-16
  surrogate pairs. Wired into `_cmsWriteWCharArray`, gated on
  `sizeof(wchar_t) > sizeof(cmsUInt16Number)` so 16-bit-`wchar_t` platforms
  (Windows) are unaffected.
- `_cmsUtf16UnitsForScalar` / `_cmsCountUtf16Units`: shared classification of
  a code point into "1 unit," "2 units," or "not a valid Unicode scalar"
  (values above U+10FFFF, or a lone surrogate code point U+D800–U+DFFF used
  directly as a scalar). Used by every site that needs to know a value's
  on-disk size, so counting and encoding can't disagree, and an unencodable
  value now makes the write fail cleanly instead of emitting structurally
  invalid UTF-16.
- `Type_Text_Description_Write`: computes the real on-disk unit count up
  front and uses it for both the declared length field and the tag-size
  calculation.
- `Type_MLU_Write`: builds a whole-pool position map (decoded `wchar_t`
  index → on-disk unit offset) once, then looks up each entry's
  `Offset`/`Len` through it. This also correctly preserves entries that
  legitimately share one on-disk string (some encoders dedup this way) — a
  naive running-offset accumulator (an earlier draft of this fix) breaks
  that case, and also validates each entry's range against the pool before
  indexing the map.
- `Type_MLU_Read`: added `convert_utf16_to_utf32_indexed`, which decodes the
  pool once while building a map from on-disk unit index to decoded
  `wchar_t` index, so each entry's `StrW`/`Len` can be resolved correctly
  after decoding instead of via the old pre-decode fixed scale. The map is
  sentinel-filled so a position landing in the middle of a surrogate pair
  (a valid byte offset, but not a valid character boundary) is explicitly
  rejected rather than silently treated as index 0, which could otherwise
  underflow the computed length.

## Testing

Added 4 regression tests to `testbed/testcms2.c` (`CheckMLU_SupplementaryPlane`,
`CheckMLU_MalformedSurrogateOffset`, `CheckMLU_SharedEntryRoundtrip`,
`CheckMLU_ScalarValidation`), covering: round-tripping a supplementary-plane
character through both `desc` and `mluc` (with the character placed before
another entry, to exercise the position-table fix); a hand-built malformed
`mluc` tag with an entry offset landing mid-surrogate-pair, confirming clean
rejection; two entries sharing one on-disk string, confirming the sharing
survives a read → write → read cycle; and boundary/invalid scalar values
(U+FFFF, U+10000, U+10FFFF valid; a lone surrogate and a value above
U+10FFFF invalid).

Full existing test suite passes with no regressions. Re-ran everything under
AddressSanitizer and macOS's `leaks` tool — both clean (0 errors, 0 leaks).

Given this touches ICC tag parsing/serialization, I tried to be conservative
and verify each change concretely rather than just by inspection — several
of the fixes above (the `Type_MLU_Read` bug, a memory leak on one of the new
error paths, and the shared-entry regression in an earlier draft of the
`Type_MLU_Write` fix) were caught this way, each confirmed by constructing a
concrete failing case and reproducing it before fixing.

No `wchar_t` used as a genuine `char16_t` on Windows should see any
behavior change — the new code paths are all gated on
`sizeof(wchar_t) > sizeof(cmsUInt16Number)`.
